### PR TITLE
Add a "none" armor options for biped swaps

### DIFF
--- a/src/Patches/Armor.cpp
+++ b/src/Patches/Armor.cpp
@@ -260,7 +260,7 @@ namespace
 		{ "base", 0 },
 		{ "stealth", 2 },
 		{ "air_assault", 3 },
-		{ "none", 4 },
+		{ "none", 3 },
 		{ "renegade", 12 },
 		{ "nihard", 13 },
 		{ "gladiator", 16 },

--- a/src/Patches/Armor.cpp
+++ b/src/Patches/Armor.cpp
@@ -423,7 +423,7 @@ namespace
 
 	std::unordered_map<std::string, uint8_t> pelvisIndexes = {
 		{ "base", 0 },
-		{ "none", 1 ),
+		{ "none", 1 },
 		{ "tankmode_human", 4 },
 	};
 }

--- a/src/Patches/Armor.cpp
+++ b/src/Patches/Armor.cpp
@@ -260,7 +260,6 @@ namespace
 		{ "base", 0 },
 		{ "stealth", 2 },
 		{ "air_assault", 3 },
-		{ "none", 3 },
 		{ "renegade", 12 },
 		{ "nihard", 13 },
 		{ "gladiator", 16 },

--- a/src/Patches/Armor.cpp
+++ b/src/Patches/Armor.cpp
@@ -260,6 +260,7 @@ namespace
 		{ "base", 0 },
 		{ "stealth", 2 },
 		{ "air_assault", 3 },
+		{ "none", 4 },
 		{ "renegade", 12 },
 		{ "nihard", 13 },
 		{ "gladiator", 16 },
@@ -290,6 +291,7 @@ namespace
 		{ "base", 0 },
 		{ "stealth", 2 },
 		{ "air_assault", 3 },
+		{ "none", 4 },
 		{ "renegade", 12 },
 		{ "nihard", 13 },
 		{ "gladiator", 16 },
@@ -321,6 +323,7 @@ namespace
 		{ "base", 0 },
 		{ "stealth", 2 },
 		{ "air_assault", 3 },
+		{ "none", 4 },
 		{ "renegade", 12 },
 		{ "nihard", 13 },
 		{ "gladiator", 16 },
@@ -351,6 +354,7 @@ namespace
 	std::unordered_map<std::string, uint8_t> armsIndexes = {
 		{ "base", 0 },
 		{ "stealth", 1 },
+		{ "none", 4 },
 		{ "renegade", 6 },
 		{ "nihard", 7 },
 		{ "gladiator", 10 },
@@ -382,6 +386,7 @@ namespace
 	std::unordered_map<std::string, uint8_t> legsIndexes = {
 		{ "base", 0 },
 		{ "stealth", 1 },
+		{ "none", 4 },
 		{ "renegade", 5 },
 		{ "nihard", 6 },
 		{ "gladiator", 9 },
@@ -418,6 +423,7 @@ namespace
 
 	std::unordered_map<std::string, uint8_t> pelvisIndexes = {
 		{ "base", 0 },
+		{ "none", 1 ),
 		{ "tankmode_human", 4 },
 	};
 }


### PR DESCRIPTION
Swapping the biped overlays spartan armor on the player, this is a workaround for biped swaps.