### PR TITLE
Stop cheat engine speedhacks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ add_library(ElDorito SHARED
     src/ThirdParty/HttpRequest.hpp
     src/ThirdParty/WebSockets.cpp
     src/ThirdParty/WebSockets.hpp
+    src/Utils/AntiSpeedHack.cpp
+    src/Utils/AntiSpeedHack.hpp
     src/Utils/Assert.cpp
     src/Utils/Assert.hpp
     src/Utils/Bits.hpp

--- a/src/ElDorito.cpp
+++ b/src/ElDorito.cpp
@@ -163,6 +163,8 @@ void ElDorito::Tick(const std::chrono::duration<double>& DeltaTime)
 	// TODO: refactor this elsewhere
 	Modules::ModuleCamera::Instance().UpdatePosition();
 
+	Utils::AntiSpeedHack::OnTickCheck();
+
 	if (executeCommandQueue)
 	{
 		Modules::CommandMap::Instance().ExecuteQueue();

--- a/src/Utils/AntiSpeedHack.cpp
+++ b/src/Utils/AntiSpeedHack.cpp
@@ -1,0 +1,47 @@
+#include <chrono>
+#include <tchar.h>
+#include <thread>
+#include <Windows.h>
+#include <Psapi.h>
+
+#include "../CommandMap.hpp"
+
+namespace Utils
+{
+	namespace AntiSpeedHack
+	{
+		static int ticks = 0;
+		void AntiSpeed()
+		{
+			HMODULE hMods[1024];
+			DWORD cbNeeded;
+			unsigned int i;
+
+			EnumProcessModules(GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded);
+			{
+				for (i = 0; i < (cbNeeded / sizeof(HMODULE)); i++)
+				{
+					TCHAR szModName[MAX_PATH];
+					if (GetModuleFileNameEx(GetCurrentProcess(), hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR)))
+					{
+						if (std::strstr(szModName, "speedhack-i386.dll") != NULL)//found speedhack dll from cheat engine.
+						{
+							Modules::CommandMap::Instance().ExecuteCommand("exit"); //exit game
+						}
+					}
+				}
+			}
+		}
+
+		void OnTickCheck()
+		{
+			if (ticks > 1000)//Only check every so many ticks
+			{
+				ticks = 0;
+				AntiSpeed();
+			}
+			else
+				ticks++;
+		}
+	}
+}

--- a/src/Utils/AntiSpeedHack.hpp
+++ b/src/Utils/AntiSpeedHack.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Utils
+{
+	namespace AntiSpeedHack
+	{
+		void AntiSpeed();
+		void OnTickCheck();
+	}
+}

--- a/src/Utils/Utils.hpp
+++ b/src/Utils/Utils.hpp
@@ -7,3 +7,4 @@
 #include "Bits.hpp"
 #include "Cryptography.hpp"
 #include "DebugLog.hpp"
+#include "AntiSpeedHack.hpp"


### PR DESCRIPTION
Simple check for cheat engine's speedhack dll every 1000 ticks. This will cut down on the amount of people speed hacking in online games.