### PR TITLE
Teamspeak Kicking

### DIFF
--- a/docs/todo-0.5.0.txt
+++ b/docs/todo-0.5.0.txt
@@ -18,7 +18,6 @@ Server browser:
 VoIp:
 - SDK Documentation:          https://halowiki.llf.to/ts3_sdk/client_html/index.html
 - Mute clients locally: (add button in D3d menu) https://halowiki.llf.to/ts3_sdk/client_html/ar01s24.html
-- kick clients from teamspeak server
 - D3d menu with microphone settings, Voice activation detection, auto gain control, mic volume, etc
 - D3d menu with current list of people in VoIP with mute buttons (if server host, kick/gag!)
 - D3d menu of current players should show their team color (or grey if non team game) also would be nice to determain if the player is dead or alive while talking (maybe put a skull next to their name)

--- a/src/Patches/Network.cpp
+++ b/src/Patches/Network.cpp
@@ -635,9 +635,11 @@ namespace
 		bool retVal = Network_leader_request_boot_machine(thisPtr, playerAddr, reason);
 		if (retVal)
 		{
-			// boot was successful, remove them from our chat now
+			// boot was successful, remove them from chat...
 			std::string ircNick = GameConsole::Instance().GenerateIRCNick(Utils::String::ThinString(playerName), uid);
 			IRCBackend::Instance().KickUser(ircNick);
+			// ...and VoIP
+			kickTeamspeakClient(Utils::String::ThinString(playerName));
 		}
 
 		return retVal;

--- a/src/VoIP/TeamspeakServer.cpp
+++ b/src/VoIP/TeamspeakServer.cpp
@@ -256,7 +256,6 @@ int kickTeamspeakClient(const std::string& name) {
 
 	if (ts3server_getClientList(1, &listClientIDs) != ERROR_ok) {
 		console.consoleQueue.pushLineFromGameToUI("Kick: Error getting list of clients (-1)");
-		ts3server_freeMemory(listClientIDs);
 		return -1;
 	}
 	for (int a = 0; listClientIDs[a] != NULL; a++) {

--- a/src/VoIP/TeamspeakServer.cpp
+++ b/src/VoIP/TeamspeakServer.cpp
@@ -264,7 +264,6 @@ int kickTeamspeakClient(const std::string& name) {
 		if (ts3server_getClientVariableAsString(1, listClientIDs[a], CLIENT_NICKNAME, &workingClientName) != ERROR_ok) {
 			console.consoleQueue.pushLineFromGameToUI("Kick: Error getting client name (-2)");
 			ts3server_freeMemory(listClientIDs);
-			ts3server_freeMemory(workingClientName);
 			return -2;
 		}
 		if (name == workingClientName) {

--- a/src/VoIP/TeamspeakServer.cpp
+++ b/src/VoIP/TeamspeakServer.cpp
@@ -3,7 +3,6 @@
 *
 * Copyright (c) 2007-2014 TeamSpeak-Systems
 * https://halowiki.llf.to/ts3_sdk/server_html/index.html
-* TODO: Kick clients:		   https://halowiki.llf.to/ts3_sdk/client_html/ar01s23s06.html
 */
 
 #ifdef _WINDOWS
@@ -20,6 +19,8 @@
 #include "../Console/GameConsole.hpp"
 #include <teamspeak/public_definitions.h>
 #include <teamspeak/public_errors.h>
+#include <teamspeak/clientlib_publicdefinitions.h>
+#include <teamspeak/clientlib.h>
 #include <teamspeak/serverlib_publicdefinitions.h>
 #include <teamspeak/serverlib.h>
 
@@ -244,6 +245,41 @@ int writeKeyPairToFile(const char *fileName, const char* keyPair) {
 	printf("Wrote keypair '%s' to file '%s'.\n", keyPair, fileName);
 	return 0;
 }
+/*
+* Kick a client given their username
+*/
+int kickTeamspeakClient(std::string name) {
+	anyID* listClientIDs;
+	char* workingClientName;
+
+	auto& console = GameConsole::Instance();
+
+	if (ts3server_getClientList(1, &listClientIDs) == ERROR_ok) {
+		for (int a = 0; a < sizeof(listClientIDs); a++) {
+			//The server ID here defaults to 1. We should have no reason to change it, but if we do, change this function and the requestKick further down
+			if (ts3server_getClientVariableAsString(1, listClientIDs[a], CLIENT_NICKNAME, &workingClientName) == ERROR_ok) {
+				std::string workingClientNameStr(workingClientName);
+				if (name == workingClientNameStr) {
+					if (ts3client_requestClientKickFromServer(1, listClientIDs[a], "Kicked from server", NULL) == ERROR_ok) {
+						break;
+					}
+				}
+			}
+			else {
+				console.consoleQueue.pushLineFromGameToUI("Kick: Error getting client name");
+				return -2;
+			}
+		}
+	}
+	else {
+		console.consoleQueue.pushLineFromGameToUI("Kick: Error getting list of clients");
+		return -1;
+	}
+	ts3server_freeMemory(listClientIDs);
+	ts3server_freeMemory(workingClientName);
+	return 0;
+}
+
 
 DWORD WINAPI StartTeamspeakServer(LPVOID) {
 	char *version;

--- a/src/VoIP/TeamspeakServer.cpp
+++ b/src/VoIP/TeamspeakServer.cpp
@@ -277,10 +277,9 @@ int kickTeamspeakClient(const std::string& name) {
 			return 0;
 		}
 	}
-	//This is unreachable code from what I can tell, but it's only a few kilobytes to cover our ass
+	//This would only trigger if we get a list of IDs with nothing in it but the null terminator
 	console.consoleQueue.pushLineFromGameToUI("Kick: Miscellaneous kick error (-4)");
 	ts3server_freeMemory(listClientIDs);
-	ts3server_freeMemory(workingClientName);
 	return -4;
 }
 

--- a/src/VoIP/TeamspeakServer.cpp
+++ b/src/VoIP/TeamspeakServer.cpp
@@ -265,15 +265,15 @@ int kickTeamspeakClient(const std::string& name) {
 			ts3server_freeMemory(listClientIDs);
 			return -2;
 		}
-		if (name == workingClientName) {
+		bool nameEvaluationBool = name == workingClientName;
+		ts3server_freeMemory(workingClientName);
+		if (nameEvaluationBool) {
 			if (ts3client_requestClientKickFromServer(1, listClientIDs[a], "Kicked from server", NULL) != ERROR_ok) {
 				console.consoleQueue.pushLineFromGameToUI("Kick: Error kicking client (-3)");
 				ts3server_freeMemory(listClientIDs);
-				ts3server_freeMemory(workingClientName);
 				return -3;
 			}
 			ts3server_freeMemory(listClientIDs);
-			ts3server_freeMemory(workingClientName);
 			return 0;
 		}
 	}

--- a/src/VoIP/TeamspeakServer.hpp
+++ b/src/VoIP/TeamspeakServer.hpp
@@ -1,3 +1,3 @@
 DWORD WINAPI StartTeamspeakServer(LPVOID);
-int kickTeamspeakClient(std::string name);
+int kickTeamspeakClient(const std::string& name);
 void StopTeamspeakServer();

--- a/src/VoIP/TeamspeakServer.hpp
+++ b/src/VoIP/TeamspeakServer.hpp
@@ -1,2 +1,3 @@
 DWORD WINAPI StartTeamspeakServer(LPVOID);
+int kickTeamspeakClient(std::string name);
 void StopTeamspeakServer();


### PR DESCRIPTION
Adds a function, `kickTeamspeakClient`, that kicks clients from the Teamspeak server. It could probably be done better with `std::vector` and `std::find`, but the function to get all connected clients returns an array so I figured I'd just loop it.