### PR TITLE
Added player name restriction

### DIFF
--- a/src/Blam/BlamNetwork.hpp
+++ b/src/Blam/BlamNetwork.hpp
@@ -288,6 +288,8 @@ namespace Blam
 
 			// Gets whether teams are enabled.
 			bool HasTeams() const;
+
+			void RestrictDisplayNames();
 		};
 		static_assert(sizeof(Session) == 0x25BC40, "Invalid c_network_session size");
 


### PR DESCRIPTION
Added player name restriction, makes sure each player's display name
consists of readable alphanumeric and symbol characters.