### PR TITLE
Added player name restriction (spaces allowed)

### DIFF
--- a/src/Blam/BlamNetwork.cpp
+++ b/src/Blam/BlamNetwork.cpp
@@ -121,8 +121,8 @@ namespace Blam
 					int value = (int)name[j];
 
 					if (value != 0) {
-						if (value < 33)
-							name[j] = (wchar_t)33;
+						if (value < 32)
+							name[j] = (wchar_t)32;
 						else if (value > 126)
 							name[j] = (wchar_t)126;
 					}

--- a/src/Blam/BlamNetwork.hpp
+++ b/src/Blam/BlamNetwork.hpp
@@ -288,6 +288,8 @@ namespace Blam
 
 			// Gets whether teams are enabled.
 			bool HasTeams() const;
+
+			void RestrictDisplayNames();
 		};
 		static_assert(sizeof(Session) == 0x25BC40, "Invalid c_network_session size");
 


### PR DESCRIPTION
Added player name restriction, makes sure each player's display name consists of readable alphanumeric characters, symbol characters, or spaces.