### PR TITLE
Revert Global Chat back to Snoonet

### DIFF
--- a/src/Console/IRCBackend.cpp
+++ b/src/Console/IRCBackend.cpp
@@ -72,9 +72,9 @@ bool IRCBackend::initIRCChat()
 	// HACK: If the IRC server is set to SnooNet, switch it to qmarchi's
 	// Otherwise people with existing cfg files will still be stuck on SnooNet
 	auto& ircvars = Modules::ModuleIRC::Instance();
-	if (ircvars.VarIRCServer->ValueString == "irc.snoonet.org")
+	if (ircvars.VarIRCServer->ValueString == "irc.justsomegamers.com")
 	{
-		ircvars.VarIRCServer->ValueString = "irc.justsomegamers.com";
+		ircvars.VarIRCServer->ValueString = "irc.snoonet.org";
 		Modules::CommandMap::Instance().ExecuteCommand("WriteConfig"); // ugh
 	}
 	


### PR DESCRIPTION
Quite pointless to have it still on irc.justsomegamers.com when its dead. A lot of people keep mentioning this 'cant connect' and think its a problem with their game.