### PR TITLE
Fixed blank variables not being sent over RCON

### DIFF
--- a/src/CommandMap.cpp
+++ b/src/CommandMap.cpp
@@ -215,7 +215,7 @@ namespace Modules
 
 		// special case for blanking strings
 		if (cmd->Type == eCommandTypeVariableString && numArgs > 1 && argsVect[0].empty())
-			cmd->ValueString = "";
+			cmd->ValueString = "\"\"";
 
 		if (numArgs <= 1)
 			return previousValue;


### PR DESCRIPTION
Commands will now return "" instead of an empty string when they are blank.

Simplest pull request ever.