### PR TITLE
voip fixes

### DIFF
--- a/src/Modules/ModuleVoIP.cpp
+++ b/src/Modules/ModuleVoIP.cpp
@@ -119,11 +119,21 @@ bool VariableServerEnabledUpdate(const std::vector<std::string>& Arguments, std:
 
 bool VariableEnabledUpdate(const std::vector<std::string>& Arguments, std::string& returnInfo)
 {
-	//TODO: Connect to lobby VOIP if changing to 1, for now this is fine because it will join next time they connet to a lobby
 	if (Modules::ModuleVoIP::Instance().VarVoIPEnabled->ValueInt == 0){
 		StopTeamspeakClient();
 	}
-	returnInfo = Modules::ModuleVoIP::Instance().VarVoIPEnabled->ValueInt ? "VoIP client will start when joining a lobby" : "Disabled VoIP.";
+	else
+	{
+		//Only if we are in a game
+		auto* session = Blam::Network::GetActiveSession();
+		if (session && session->IsEstablished())
+		{
+			//Make sure teamspeak is stopped before we try to start it.
+			StopTeamspeakClient();
+			CreateThread(0, 0, StartTeamspeakClient, 0, 0, 0);
+		}
+	}
+	returnInfo = Modules::ModuleVoIP::Instance().VarVoIPEnabled->ValueInt ? "VoIP client will attempt to rejoin server if you are in one." : "Disabled VoIP.";
 	return true;
 }
 

--- a/src/Modules/ModuleVoIP.cpp
+++ b/src/Modules/ModuleVoIP.cpp
@@ -172,6 +172,27 @@ bool CommandVoIPMutePlayer(const std::vector<std::string>& Arguments, std::strin
 	return false;
 }
 
+bool CommandVoipRetryConnection(const std::vector<std::string>& Arguments, std::string& returnInfo)
+{
+	auto* session = Blam::Network::GetActiveSession();
+	if (!session || !session->IsEstablished())
+	{
+		returnInfo = "No session found, are you in a game?";
+		return false;
+	}
+
+	if (Modules::ModuleVoIP::Instance().VarVoIPEnabled->ValueInt != 1)
+	{
+		returnInfo = "You do not have voip enabled";
+		return false;
+	}
+
+	//Make sure teamspeak is stopped before we try to start it.
+	StopTeamspeakClient();
+	CreateThread(0, 0, StartTeamspeakClient, 0, 0, 0);
+	return true;
+}
+
 namespace Modules
 {
 	ModuleVoIP::ModuleVoIP() : ModuleBase("VoIP")
@@ -224,6 +245,8 @@ namespace Modules
 		VarVoIPEnabled->ValueIntMax = 1;
 
 		AddCommand("MutePlayer", "mute", "Toggles mute on a player in VoIP", eCommandFlagsNone, CommandVoIPMutePlayer, { "playername/UID The name or UID of the player to mute or unmute" });
+
+		AddCommand("Retry", "retry", "Retry voip connection to currently connected server", eCommandFlagsNone, CommandVoipRetryConnection);
 
 	}
 }

--- a/src/VoIP/TeamspeakClient.cpp
+++ b/src/VoIP/TeamspeakClient.cpp
@@ -134,12 +134,9 @@ void onConnectStatusChangeEvent(uint64 serverConnectionHandlerID, int newStatus,
 		selfID = -1;
 		StopTeamspeakClient();
 	}
-	else if (newStatus == STATUS_CONNECTED)//Find out client id
+	else if (newStatus == STATUS_CONNECTED)
 	{
-		anyID id;
-		ts3client_getClientID(serverConnectionHandlerID, &id);
-		selfID = id;
-		ts3client_freeMemory(&id);
+		ts3client_getClientID(serverConnectionHandlerID, &selfID);
 	}
 }
 

--- a/src/VoIP/TeamspeakClient.cpp
+++ b/src/VoIP/TeamspeakClient.cpp
@@ -1233,10 +1233,10 @@ std::string IpToString(const Blam::Network::NetworkAddress &addr)
 
 void onConnectionInfoEvent(uint64 serverConnectionHandlerID, anyID clientID)
 {
-	if (clientID == 1)//ignore self
+	if (clientID == selfID)
 		return;
 	auto& console = GameConsole::Instance();
-	Sleep(1000); //Give a moment for clients to be in-game
+	Sleep(1000);
 	auto* session = Blam::Network::GetActiveSession();
 	if (!session || !session->IsEstablished() || !session->IsHost())
 		return;
@@ -1250,7 +1250,7 @@ void onConnectionInfoEvent(uint64 serverConnectionHandlerID, anyID clientID)
 		char *name;
 		if (ts3client_getClientVariableAsString(serverConnectionHandlerID, clientID, CLIENT_NICKNAME, &name) != ERROR_ok)
 		{
-			
+			console.consoleQueue.pushLineFromGameToUI("VoIP: Could not determine client id: " + std::to_string(clientID) + "'s name");
 		}
 		//can't integrate banlist into server connection event on serverside since we need ip first. Can't get ip until we have requested connection info from server.
 		//There is no available server function that will return the ip, only client can request and view ip
@@ -1304,7 +1304,7 @@ void onClientKickFromServerEvent(uint64 serverConnectionHandlerID, anyID clientI
 
 DWORD WINAPI StartTeamspeakClient(LPVOID) {
 	
-	Sleep(750);//Doing this allows us to abort the current client thread before creating a new one and running into problems
+	Sleep(750);
 	unsigned int error;
 	char* mode;
 	char** device;

--- a/src/VoIP/TeamspeakClient.cpp
+++ b/src/VoIP/TeamspeakClient.cpp
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <queue>
 
 #include <teamspeak/public_definitions.h>
 #include <teamspeak/public_errors.h>
@@ -80,6 +79,11 @@ INT VoIPGetTalkStatus()
 	return vadTestTalkStatus;
 }
 
+anyID selfID = -1;
+anyID VoIPGetClientID()
+{
+	return selfID;
+}
 
 /* Enable to use custom encryption */
 /* #define USE_CUSTOM_ENCRYPTION
@@ -127,7 +131,15 @@ void onConnectStatusChangeEvent(uint64 serverConnectionHandlerID, int newStatus,
 	/* Failed to connect ? */
 	if(newStatus == STATUS_DISCONNECTED || errorNumber == ERROR_failed_connection_initialisation || errorNumber  == ERROR_connection_lost) {
 		console.consoleQueue.pushLineFromGameToUI("Looks like there is no server running.\n");
+		selfID = -1;
 		StopTeamspeakClient();
+	}
+	else if (newStatus == STATUS_CONNECTED)//Find out client id
+	{
+		anyID id;
+		ts3client_getClientID(serverConnectionHandlerID, &id);
+		selfID = id;
+		ts3client_freeMemory(&id);
 	}
 }
 

--- a/src/VoIP/TeamspeakClient.cpp
+++ b/src/VoIP/TeamspeakClient.cpp
@@ -253,6 +253,11 @@ void onClientMoveSubscriptionEvent(uint64 serverConnectionHandlerID, anyID clien
 void onClientMoveTimeoutEvent(uint64 serverConnectionHandlerID, anyID clientID, uint64 oldChannelID, uint64 newChannelID, int visibility, const char* timeoutMessage) {
 	auto& console = GameConsole::Instance();
 	console.consoleQueue.pushLineFromGameToUI("ClientID " + std::to_string(clientID) + " timeouts with message " + std::string(timeoutMessage));
+	char *name;
+	if (ts3client_getClientVariableAsString(serverConnectionHandlerID, clientID, CLIENT_NICKNAME, &name) != ERROR_ok)
+		return;
+	MemberList::Instance().HidePlayerTalkEvent(name);
+	ts3client_freeMemory(name);
 }
 
 /*

--- a/src/VoIP/TeamspeakClient.cpp
+++ b/src/VoIP/TeamspeakClient.cpp
@@ -11,6 +11,8 @@
 #ifdef _WIN32
 #define _CRT_SECURE_NO_WARNINGS
 #pragma warning(disable : 4996)
+#include <WinSock2.h>
+#include <WS2tcpip.h>
 #include <Windows.h>
 #include <conio.h>
 #else
@@ -21,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <queue>
 
 #include <teamspeak/public_definitions.h>
 #include <teamspeak/public_errors.h>
@@ -34,7 +37,10 @@
 #include "../ElDorito.hpp"
 #include "../VoIP/MemberList.hpp"
 #include "../Modules/ModulePlayer.hpp"
+#include "../Modules/ModuleServer.hpp"
+#include "../Server/BanList.hpp"
 #include "TeamspeakClient.hpp"
+#include "TeamspeakServer.hpp"
 #include <cstdint>
 #define DEFAULT_VIRTUAL_SERVER 1
 #define NAME_BUFSIZE 1024
@@ -119,7 +125,7 @@ void onConnectStatusChangeEvent(uint64 serverConnectionHandlerID, int newStatus,
 	auto& console = GameConsole::Instance();
 	console.consoleQueue.pushLineFromGameToUI("Connect status changed : " + std::to_string(serverConnectionHandlerID) + " " + std::to_string(newStatus) + " " + std::to_string(errorNumber));
 	/* Failed to connect ? */
-	if(newStatus == STATUS_DISCONNECTED && errorNumber == ERROR_failed_connection_initialisation) {
+	if(newStatus == STATUS_DISCONNECTED || errorNumber == ERROR_failed_connection_initialisation || errorNumber  == ERROR_connection_lost) {
 		console.consoleQueue.pushLineFromGameToUI("Looks like there is no server running.\n");
 		StopTeamspeakClient();
 	}
@@ -1198,6 +1204,87 @@ int muteTeamspeakClient(const std::string& name) {
 	return -6;
 }
 
+std::string IpToString(const Blam::Network::NetworkAddress &addr)
+{
+	struct in_addr inAddr;
+	inAddr.S_un.S_addr = addr.ToInAddr();
+	char ipStr[INET_ADDRSTRLEN];
+	if (!inet_ntop(AF_INET, &inAddr, ipStr, sizeof(ipStr)))
+		return "";
+	return std::string(ipStr);
+}
+
+void onConnectionInfoEvent(uint64 serverConnectionHandlerID, anyID clientID)
+{
+	if (clientID == 1)//ignore self
+		return;
+	auto& console = GameConsole::Instance();
+	Sleep(1000); //Give a moment for clients to be in-game
+	auto* session = Blam::Network::GetActiveSession();
+	if (!session || !session->IsEstablished() || !session->IsHost())
+		return;
+
+	auto membership = &session->MembershipInfo;
+	char *ip;
+	unsigned int error = 0xFFFF;
+
+	if ((error = ts3client_getConnectionVariableAsString(serverConnectionHandlerID, clientID, CONNECTION_CLIENT_IP, &ip)) == ERROR_ok)
+	{
+		char *name;
+		if (ts3client_getClientVariableAsString(serverConnectionHandlerID, clientID, CLIENT_NICKNAME, &name) != ERROR_ok)
+		{
+			
+		}
+		//can't integrate banlist into server connection event on serverside since we need ip first. Can't get ip until we have requested connection info from server.
+		//There is no available server function that will return the ip, only client can request and view ip
+		Server::BanList banList = Server::LoadDefaultBanList();
+		if (banList.ContainsIp(std::string(ip)))
+		{
+			if (ts3client_requestClientKickFromServer(serverConnectionHandlerID, clientID, "Kicked from server", NULL) != ERROR_ok)
+				console.consoleQueue.pushLineFromGameToUI("VoIP: error kicking banned ip " + std::string(ip));
+			else
+				console.consoleQueue.pushLineFromGameToUI("VoIP: kicked banned ip " + std::string(ip));
+		}
+			
+
+		bool foundMatch = false;
+		for (auto peerIdx = membership->FindFirstPeer(); peerIdx >= 0; peerIdx = membership->FindNextPeer(peerIdx))
+		{
+			std::string peerIp = IpToString(session->GetPeerAddress(session->MembershipInfo.GetPlayerPeer(peerIdx)));
+			if (peerIp.compare(std::string(ip)) == 0)
+			{
+				foundMatch = true;
+				break;
+			}
+		}
+		if (!foundMatch)
+		{
+			if (ts3client_requestClientKickFromServer(serverConnectionHandlerID, clientID, "Kicked from server", NULL) == ERROR_ok)
+				console.consoleQueue.pushLineFromGameToUI("VoIP: Kicked client since not in-game: " + std::string(ip) + " (" + std::string(name) + ")");
+			else
+				console.consoleQueue.pushLineFromGameToUI("VoIP: error kicking: " + std::string(ip));
+		}
+		ts3client_freeMemory(name);
+		ts3client_freeMemory(ip);
+	}
+	else
+	{
+		char buf[6];
+		sprintf(buf, "%u", error);
+		console.consoleQueue.pushLineFromGameToUI("VoIP: Errorcode: " + std::string(buf));
+	}
+}
+
+void onClientKickFromServerEvent(uint64 serverConnectionHandlerID, anyID clientID, uint64 oldChannelID, uint64 newChannelID, int visibility, anyID kickerID, const char* kickerName, const char* kickerUniqueIdentifier, const char* kickMessage)
+{
+	char *name;
+	if (ts3client_getClientVariableAsString(serverConnectionHandlerID, clientID, CLIENT_NICKNAME, &name) == ERROR_ok)
+	{
+		MemberList::Instance().HidePlayerTalkEvent(std::string(name));
+		ts3client_freeMemory(name);
+	}
+}
+
 DWORD WINAPI StartTeamspeakClient(LPVOID) {
 	
 	unsigned int error;
@@ -1232,6 +1319,8 @@ DWORD WINAPI StartTeamspeakClient(LPVOID) {
 	funcs.onCustomPacketEncryptEvent = onCustomPacketEncryptEvent;
 	funcs.onCustomPacketDecryptEvent = onCustomPacketDecryptEvent;
 	funcs.onEditMixedPlaybackVoiceDataEvent = onEditMixedPlaybackVoiceDataEvent;
+	funcs.onConnectionInfoEvent = onConnectionInfoEvent;
+	funcs.onClientKickFromServerEvent = onClientKickFromServerEvent;
 #ifdef CUSTOM_PASSWORDS
 	funcs.onClientPasswordEncrypt           = onClientPasswordEncrypt;
 #endif
@@ -1533,6 +1622,7 @@ DWORD WINAPI StartTeamspeakClient(LPVOID) {
 	recordSound = 0;
 	onEditMixedPlaybackVoiceDataEvent(DEFAULT_VIRTUAL_SERVER, NULL, 0, 0, NULL, NULL);
 	console.consoleQueue.pushLineFromGameToUI("Stopped Eldewrito VoIP Client");
+	MemberList::Instance().memberList.clear();
 	return 0;
 }
 

--- a/src/VoIP/TeamspeakClient.cpp
+++ b/src/VoIP/TeamspeakClient.cpp
@@ -1287,6 +1287,7 @@ void onClientKickFromServerEvent(uint64 serverConnectionHandlerID, anyID clientI
 
 DWORD WINAPI StartTeamspeakClient(LPVOID) {
 	
+	Sleep(750);//Doing this allows us to abort the current client thread before creating a new one and running into problems
 	unsigned int error;
 	char* mode;
 	char** device;

--- a/src/VoIP/TeamspeakClient.hpp
+++ b/src/VoIP/TeamspeakClient.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Windows.h>
+#include <teamspeak/public_definitions.h>
 
 DWORD WINAPI StartTeamspeakClient(LPVOID);
 void StopTeamspeakClient();
@@ -9,3 +10,4 @@ int muteTeamspeakClient(const std::string& name);
 UINT64 VoIPGetscHandlerID();
 UINT64 VoIPGetVadHandlerID();
 INT VoIPGetTalkStatus();
+anyID VoIPGetClientID();

--- a/src/VoIP/TeamspeakServer.cpp
+++ b/src/VoIP/TeamspeakServer.cpp
@@ -293,7 +293,7 @@ int kickTeamspeakClient(const std::string& name) {
 //prevent leaking clients ips to other clients with modified dlls
 unsigned int permSendConnectionInfo(uint64 serverID, const struct ClientMiniExport* client, int* mayViewIpPort, const struct ClientMiniExport* targetClient)
 {
-	if (client->ID == VoIPGetClientID())//owner
+	if (client->ID == VoIPGetClientID())
 		return ERROR_ok;
 	else
 		return ERROR_permissions_client_insufficient;
@@ -302,12 +302,31 @@ unsigned int permSendConnectionInfo(uint64 serverID, const struct ClientMiniExpo
 //prevent anyone from kicking anyone
 unsigned int permClientKickFromServer(uint64 serverID, const struct ClientMiniExport* client, int toKickCount, struct ClientMiniExport* toKickClients, const char* reasonText)
 {
-	if (client->ID == VoIPGetClientID())//owner
+	if (client->ID == VoIPGetClientID())
 		return ERROR_ok;
 	else
 		return ERROR_permissions_client_insufficient;
 }
 
+unsigned int permChannelDelete(uint64 serverID, const struct ClientMiniExport* client, uint64 channelID)
+{
+	return ERROR_permissions_client_insufficient;
+}
+
+unsigned int permChannelEdit(uint64 serverID, const struct ClientMiniExport* client, uint64 channelID, struct VariablesExport* variables)
+{
+	return ERROR_permissions_client_insufficient;
+}
+
+unsigned int permChannelMove(uint64 serverID, const struct ClientMiniExport* client, uint64 channelID, uint64 newParentChannelID)
+{
+	return ERROR_permissions_client_insufficient;
+}
+
+unsigned int permChannelCreate(uint64 serverID, const struct ClientMiniExport* client, uint64 parentChannelID, struct VariablesExport* variables)
+{
+	return ERROR_permissions_client_insufficient;
+}
 
 DWORD WINAPI StartTeamspeakServer(LPVOID) {
 	char *version;
@@ -340,6 +359,10 @@ DWORD WINAPI StartTeamspeakServer(LPVOID) {
 	funcs.onAccountingErrorEvent = onAccountingErrorEvent;
 	funcs.permSendConnectionInfo = permSendConnectionInfo;
 	funcs.permClientKickFromServer = permClientKickFromServer;
+	funcs.permChannelDelete = permChannelDelete;
+	funcs.permChannelEdit = permChannelEdit;
+	funcs.permChannelMove = permChannelMove;
+	funcs.permChannelCreate = permChannelCreate;
 
 	/* Initialize server lib with callbacks */
 	if ((error = ts3server_initServerLib(&funcs, LogType_FILE | LogType_CONSOLE | LogType_USERLOGGING, NULL)) != ERROR_ok) {

--- a/src/VoIP/TeamspeakServer.cpp
+++ b/src/VoIP/TeamspeakServer.cpp
@@ -23,7 +23,8 @@
 #include <teamspeak/clientlib.h>
 #include <teamspeak/serverlib_publicdefinitions.h>
 #include <teamspeak/serverlib.h>
-
+#include "../Modules/ModuleVoIP.hpp"
+#include "TeamspeakClient.hpp"
 
 #ifdef _WIN32
 #define snprintf sprintf_s
@@ -50,7 +51,8 @@ void onClientConnected(uint64 serverID, anyID clientID, uint64 channelID, unsign
 	console.consoleQueue.pushLineFromGameToUI("Client " + std::to_string(clientID) + " joined channel " + std::to_string((unsigned long long)channelID) + " on Eldewrito VoIP Server " + std::to_string((unsigned long long)serverID));
 #endif
 
-	ts3client_requestConnectionInfo(serverID, clientID, NULL); //handle kicking in callback function
+	if (Modules::ModuleVoIP::Instance().VarVoIPEnabled->ValueInt != 0)
+		ts3client_requestConnectionInfo(serverID, clientID, NULL); //handle kicking in callback function
 
 	//Note: we can prevent clients from connecting by changing the removeClientError
 	//This would be very useful if a client is in some kind of ban list...
@@ -291,7 +293,7 @@ int kickTeamspeakClient(const std::string& name) {
 //prevent leaking clients ips to other clients with modified dlls
 unsigned int permSendConnectionInfo(uint64 serverID, const struct ClientMiniExport* client, int* mayViewIpPort, const struct ClientMiniExport* targetClient)
 {
-	if (client->ID == 1)//owner
+	if (client->ID == VoIPGetClientID())//owner
 		return ERROR_ok;
 	else
 		return ERROR_permissions_client_insufficient;
@@ -300,7 +302,7 @@ unsigned int permSendConnectionInfo(uint64 serverID, const struct ClientMiniExpo
 //prevent anyone from kicking anyone
 unsigned int permClientKickFromServer(uint64 serverID, const struct ClientMiniExport* client, int toKickCount, struct ClientMiniExport* toKickClients, const char* reasonText)
 {
-	if (client->ID == 1)//owner
+	if (client->ID == VoIPGetClientID())//owner
 		return ERROR_ok;
 	else
 		return ERROR_permissions_client_insufficient;


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Fixes voip being stuck in a disconnected state after a server crash or being kicked.

2. Adds a voip.retry command to restart the teamspeak client.

3. voip.enabled 0 and then 1 will reconnect to the server if they are in one.

4. voip server should adhere to banlist but the user needs voip.enabled 1 because only clients can view the ip of other clients for some reason. Also connecting players must be a player in-game or they will be kicked from teamspeak.

5. Limits what a user with a modified dll can do. (Currently anyone in the ts server can kick any other person or view another user's ip address)

6. Clears names speaking when another user is kicked or disconnected. Also clears all names when the teamspeak client is shutdown.

### Why should this pull request be merged?

Should stop voip spam and no longer require users to rejoin servers when they can't hear other players with voip.retry. Fixes permissions up a little in case someone plans to exploit them.

### Have you tested this on your own and/or in a game with other people?

Tested with full games a few times, no issues except for an instance where a player was using a vpn and had a different ip when connecting between teamspeak and the game.