### PR TITLE
Added Accessories to Armory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,8 @@ add_library(ElDorito SHARED
     src/Patches/Scoreboard.hpp
     src/Patches/Sprint.cpp
     src/Patches/Sprint.hpp
+    src/Patches/Gravity.cpp
+    src/Patches/Gravity.hpp
     src/Patches/Ui.cpp
     src/Patches/Ui.hpp
     src/Patches/VirtualKeyboard.cpp

--- a/src/ElPatches.cpp
+++ b/src/ElPatches.cpp
@@ -16,6 +16,7 @@
 #include "Patches\CustomPackets.hpp"
 #include "Patches\Logging.hpp"
 #include "Patches\Sprint.hpp"
+#include "Patches\Gravity.hpp"
 #include "Patches\Assassination.hpp"
 #include "Modules\ModuleCamera.hpp"
 

--- a/src/Modules/ModuleServer.cpp
+++ b/src/Modules/ModuleServer.cpp
@@ -20,6 +20,7 @@
 #include "../Server/VariableSynchronization.hpp"
 #include "../Patches/Assassination.hpp"
 #include "../Patches/Sprint.hpp"
+#include "../Patches/Gravity.hpp"
 #include "../Server/BanList.hpp"
 #include "../Server/ServerChat.hpp"
 
@@ -910,6 +911,14 @@ namespace
 		Patches::Sprint::SetUnlimited(unlimited);
 		return true;
 	}
+	
+	bool GravityEnabledChanged(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		auto &serverModule = Modules::ModuleServer::Instance();
+		auto enabled = serverModule.VarServerGravityEnabledClient->ValueInt != 0;
+		Patches::Gravity::Enable(enabled);
+		return true;
+	}
 
 	bool AssassinationDisabledChanged(const std::vector<std::string>& Arguments, std::string& returnInfo)
 	{
@@ -981,6 +990,10 @@ namespace Modules
 		VarServerSprintUnlimited = AddVariableInt("UnlimitedSprint", "unlimited_sprint", "Controls whether unlimited sprint is enabled on the server", static_cast<CommandFlags>(eCommandFlagsArchived | eCommandFlagsReplicated), 0);
 		VarServerSprintUnlimitedClient = AddVariableInt("UnlimitedSprintClient", "unlimited_sprint_client", "", eCommandFlagsInternal, 0, UnlimitedSprintEnabledChanged);
 		Server::VariableSynchronization::Synchronize(VarServerSprintUnlimited, VarServerSprintUnlimitedClient);
+		
+		VarServerGravityEnabled = AddVariableInt("GravityEnabled", "gravity", "Controls whether gravity is enabled on the server", static_cast<CommandFlags>(eCommandFlagsArchived | eCommandFlagsReplicated), 1);
+		VarServerGravityEnabledClient = AddVariableInt("GravityEnabledClient", "gravity_client", "", eCommandFlagsInternal, 1, GravityEnabledChanged);
+		Server::VariableSynchronization::Synchronize(VarServerGravityEnabled, VarServerGravityEnabledClient);
 
 		VarServerDualWieldEnabled = AddVariableInt("DualWieldEnabled", "dualwield", "Controls whether dual wielding is enabled on the server", static_cast<CommandFlags>(eCommandFlagsArchived | eCommandFlagsReplicated), 1);
 		VarServerDualWieldEnabledClient = AddVariableInt("DualWieldEnabledClient", "dualwield_client", "", eCommandFlagsInternal, 0);

--- a/src/Modules/ModuleServer.hpp
+++ b/src/Modules/ModuleServer.hpp
@@ -19,6 +19,8 @@ namespace Modules
 		Command* VarServerSprintEnabledClient;
 		Command* VarServerSprintUnlimited;
 		Command* VarServerSprintUnlimitedClient;
+		Command* VarServerGravityEnabled;
+		Command* VarServerGravityEnabledClient;
 		Command* VarServerDualWieldEnabled;
 		Command* VarServerDualWieldEnabledClient;
 		Command* VarServerAssassinationEnabled;

--- a/src/Patches/Armor.cpp
+++ b/src/Patches/Armor.cpp
@@ -431,6 +431,33 @@ namespace
 	};
 
 	std::unordered_map<std::string, uint8_t> accIndexes = {
+		/* I know these are null variants but this helps with adding effect mods.
+		Using these by default in no way effects the game. */
+		{ "base", 0 },
+		{ "katana", 1 },
+		{ "antenna_01", 2 },
+		{ "knife_02", 3 },
+		{ "tools_bag_01", 4 },
+		{ "knife_01", 5 },
+		{ "throwing_knives", 6 },
+		{ "bullet_shield", 7 },
+		{ "medkit", 8 },
+		{ "ammo_pack", 9 },
+		{ "target_painter", 10 },
+		{ "grenade_01", 11 },
+		{ "reactive_armor_arm", 12 },
+		{ "reactive_armor_leg", 13 },
+		{ "dog_tag_01", 14 },
+		{ "chest_battery", 15 },
+		{ "ammo_belt", 16 },
+		{ "flashlight", 17 },
+		{ "shotgun_ammo", 18 },
+		{ "holo_scope", 19 },
+		{ "hud_screen", 20 },
+		{ "antenna_02", 21 },
+		{ "generator_device", 22 },
+		{ "reactive_armor_plate", 23 },
+		{ "electronic_tool", 24 },
 	};
 
 	std::unordered_map<std::string, uint8_t> pelvisIndexes = {

--- a/src/Patches/Gravity.cpp
+++ b/src/Patches/Gravity.cpp
@@ -1,0 +1,37 @@
+#include "Gravity.hpp"
+#include "../Patch.hpp"
+#include "../ElDorito.hpp"
+
+namespace
+{
+	bool GravityEnabled = true;
+}
+
+namespace Patches
+{
+	namespace Gravity
+	{
+		void Enable(bool enabled)
+		{
+			GravityEnabled = enabled;
+			if (enabled)
+			{
+				auto &gravityPtr = ElDorito::GetMainTls(GameGlobals::Physics::TLSOffset)[0];
+				if (&gravityPtr)
+					gravityPtr.Write(GameGlobals::Physics::DefaultGravity);
+			}
+
+			else
+			{
+				auto &gravityPtr = ElDorito::GetMainTls(GameGlobals::Physics::TLSOffset)[0];
+				if (&gravityPtr)
+					gravityPtr(GameGlobals::Physics::GravityIndex).Write<float>(0);
+			}
+		}
+
+		void Tick()
+		{
+			//OnEvent (Not Needed)
+		}
+	}
+}

--- a/src/Patches/Gravity.hpp
+++ b/src/Patches/Gravity.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Patches
+{
+	namespace Gravity
+	{
+		void Enable(bool enabled);
+		void Tick();
+	}
+}


### PR DESCRIPTION
### Proposed changes in this pull request:
1. Added the accessories to the armory index so people can make mods using that index to load armor effects. All Acc index tag references are null so accidentally using one will in no way effect ElDewrito.
### Why should this pull request be merged?

With this added I (XeCREATURE) won't have to release a separate mtndew.dll with my mods. In addition other modders can use this to make armor effect mods.
### Have you tested this on your own and/or in a game with other people?

Yes, I have tested online, offline, and with a multitude of armor combinations. This won't break the base armory set in any way. This has also been released before with some of my other mods.
