### PR TITLE
Fix hang on Game.Exit

### DIFF
--- a/src/Modules/ModuleGame.cpp
+++ b/src/Modules/ModuleGame.cpp
@@ -10,6 +10,7 @@
 #include "../Blam/BlamNetwork.hpp"
 #include "../Blam/Tags/Game/GameEngineSettings.hpp"
 #include "../Patches/Forge.hpp"
+#include "../Web/WebRenderer.hpp"
 #include "../Web/Ui/ScreenLayer.hpp"
 #include "ModuleServer.hpp"
 #include "../Patch.hpp"
@@ -297,6 +298,7 @@ namespace
 
 	bool CommandGameExit(const std::vector<std::string>& Arguments, std::string& returnInfo)
 	{
+		Anvil::Client::Rendering::WebRenderer::GetInstance()->Shutdown();
 		std::exit(0);
 		return true;
 	}


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Shutdown cef on Game.Exit/Exit

### Why should this pull request be merged?

Exit no longer causes halo to hang.

### Have you tested this on your own and/or in a game with other people?

N/A

Literally the simplest change ever.