### PR TITLE
Added Voice Chat HUD Widgets to the UI Patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ add_library(ElDorito SHARED
     src/Blam/Tags/Sounds/Noise.hpp
     src/Blam/Tags/UI/ChudDefinition.hpp
     src/Blam/Tags/UI/ChudGlobalsDefinition.hpp
+    src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
     src/Console.cpp
     src/Console.hpp
     src/DirectXHook.cpp

--- a/src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
+++ b/src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <cstdint>
+#include "../Tags.hpp"
+#include "../../Text/StringID.hpp"
+#include <string>
+
+namespace Blam
+{
+	namespace Tags
+	{
+		namespace UI
+		{
+			using Blam::Tags::TagBlock;
+			using Blam::Tags::TagData;
+			using Blam::Tags::TagGroup;
+			using Blam::Tags::TagReference;
+			using Blam::Text::StringID;
+
+			struct MultilingualUnicodeStringList : TagGroup<'unic'>
+			{
+				struct LocalizedString;
+
+				TagBlock<LocalizedString> Strings;
+			    TagData<int8_t> Data;
+
+				struct LocalizedString
+				{
+					StringID StringID;
+					int32_t Unknown[8]; //This stuff is actually known, just not mapped out. There's a string in here.
+					int32_t Offsets[12];
+				};
+				TAG_STRUCT_SIZE_ASSERT(LocalizedString, 0x54);
+			};
+		}
+	}
+}

--- a/src/Patches/Ui.cpp
+++ b/src/Patches/Ui.cpp
@@ -9,6 +9,12 @@
 #include "../Blam/BlamNetwork.hpp"
 #include "../Modules/ModuleGraphics.hpp"
 #include "../Web/Ui/ScreenLayer.hpp"
+#include "../Blam/Tags/UI/MultilingualUnicodeStringList.hpp"
+#include <iostream>
+#include <string>
+#include <locale>
+#include <codecvt>
+#include <iomanip>
 
 using namespace Patches::Ui;
 
@@ -30,6 +36,9 @@ namespace
 	std::vector<CreateWindowCallback> createWindowCallbacks;
 
 	Patch unused; // for some reason a patch field is needed here (on release builds) otherwise the game crashes while loading map/game variants, wtf?
+
+	Patches::Ui::VoIPIcon micState = Patches::Ui::VoIPIcon::Unavailable;
+	bool someoneSpeaking;
 }
 
 namespace Patches
@@ -605,5 +614,186 @@ namespace
 			callback(hwnd);
 
 		return hwnd;
+	}
+
+
+	void SetVoIPIcon(Patches::Ui::VoIPIcon _micState)
+	{
+		micState = _micState;
+		UpdateVoIPIcons();
+	}
+
+	void ToggleSpeaker(bool _enabled)
+	{
+		someoneSpeaking = _enabled;
+		UpdateVoIPIcons();
+	}
+
+	bool firstStringUpdate = true;
+	int speakingPlayerOffset; //The offset of speaker_name in memory.
+	static const char* const hex = "0123456789ABCDEF";
+	std::string hudMessagesStrings;
+	std::stringstream hexStringStream;
+	std::string hudMessagesStringsLeft;
+	std::string hudMessagesStringsRight;
+
+	void SetSpeakingPlayer(std::string speakingPlayer)
+	{
+		//This method could use some refactoring, and performance could be improved I think.
+		using Blam::Tags::TagInstance;
+		using Blam::Tags::UI::MultilingualUnicodeStringList;
+
+		if (speakingPlayer.length() > 15)
+			return;
+
+		auto *unic = Blam::Tags::TagInstance(0x12c2).GetDefinition<Blam::Tags::UI::MultilingualUnicodeStringList>();
+
+		if (firstStringUpdate)
+		{
+			//go through string blocks backwards to find speaking_player, as it should be at the end.
+			for (int stringBlockIndex = unic->Strings.Count - 1; stringBlockIndex > -1; --stringBlockIndex)
+				if (unic->Strings[stringBlockIndex].StringID == 0x9202) // speaking_player
+				{
+					speakingPlayerOffset = unic->Strings[stringBlockIndex].Offsets[0]; //read the english offset,
+					break;
+				}
+
+			//If the speaking_player string cannot be found, RIP. This shouldn't happen unless tags don't have correct modifications.
+			if (speakingPlayerOffset == NULL)
+				throw nullptr;
+
+			//Only grab the beginning and end strings once, as these should not change.
+			//If in the future other patches manipulate strings, this should be moved to unic tag definition.
+			unsigned char *byteData = reinterpret_cast<unsigned char*>(unic->Data.Elements);
+
+			hexStringStream << std::hex << std::setfill('0');
+			for (size_t index = 0; index < unic->Data.Size; ++index)
+				hexStringStream << std::setw(2) << static_cast<int>(byteData[index]);
+
+			hudMessagesStrings = hexStringStream.str();
+
+			//Strings before and after speaking_player.
+			hudMessagesStringsLeft = hudMessagesStrings;
+			hudMessagesStringsRight = hudMessagesStrings;
+			hudMessagesStringsLeft = hudMessagesStringsLeft.erase(speakingPlayerOffset * 2, hudMessagesStringsLeft.npos);
+			hudMessagesStringsRight = hudMessagesStringsRight.erase(0, (speakingPlayerOffset * 2) + 30);
+
+			firstStringUpdate = false;
+		}
+
+		std::string newHudMessagesStrings;
+		newHudMessagesStrings.reserve(30);
+
+		for (size_t i = 0; i < speakingPlayer.length(); ++i)
+		{
+			const unsigned char c = speakingPlayer[i];
+			newHudMessagesStrings.push_back(hex[c >> 4]);
+			newHudMessagesStrings.push_back(hex[c & 15]);
+		}
+
+		//if the speaker name is less than 15 characters, fill the rest of the string with 0.
+		if (speakingPlayer.length() < (size_t)15)
+			for (int i = speakingPlayer.length() * 2; i < 30; ++i)
+				newHudMessagesStrings.push_back('0');
+
+		//Add the strings before speaking_player, the new speaking_player string and the strings after speaking_player together.
+		newHudMessagesStrings.reserve(hudMessagesStrings.length());
+		newHudMessagesStrings = hudMessagesStringsLeft + newHudMessagesStrings + hudMessagesStringsRight;
+
+		//Now convert the hex string to a byte array and poke!
+		hexStringStream >> std::hex;
+		for (size_t strIndex = 0, dataIndex = 0; strIndex < (size_t)newHudMessagesStrings.length(); ++dataIndex)
+		{
+			// Read out and convert the string two characters at a time
+			const char tmpStr[3] = { newHudMessagesStrings[strIndex++], newHudMessagesStrings[strIndex++], 0 };
+
+			// Reset and fill the string stream
+			hexStringStream.clear();
+			hexStringStream.str(tmpStr);
+
+			// Do the conversion
+			int tmpValue = 0;
+			hexStringStream >> tmpValue;
+			unic->Data.Elements[dataIndex] = static_cast<unsigned char>(tmpValue);
+		}
+	}
+
+	bool firstHudUpdate = true;
+	int teamBroadcastIndicatorIndex = 0; //Hud Widget containing Icons.
+	int broadcastAvailableIndex = 0; //Can Talk Icon
+	int broadcastIndex = 0; //Talking Icon.
+	int broadcastPTTIndex = 0; //Push To Talk Icon
+	int broadcastNoIndex = 0; //Can't Talk Icon
+	int speakingPlayerIndex = 0; //Hud Widget Containing Speaker.
+
+	void UpdateVoIPIcons()
+	{
+		using Blam::Tags::TagInstance;
+		using Blam::Tags::UI::ChudDefinition;
+
+		auto *chud = Blam::Tags::TagInstance(0x12BD).GetDefinition<Blam::Tags::UI::ChudDefinition>();
+
+		//If it's the first time updating the HUD, find the tagblock indexes.
+		if (firstHudUpdate)
+		{
+			for (int hudWidgetBlock = 0; hudWidgetBlock < chud->HudWidgets.Count; hudWidgetBlock = hudWidgetBlock + 1)//New to the syntax, increment operator might be better. -Alex.
+			{
+				if (chud->HudWidgets[hudWidgetBlock].NameStringID == 0x45C2) // team_broadcast_indicator
+				{
+					teamBroadcastIndicatorIndex = hudWidgetBlock;
+
+					for (int bitmapWidgetBlock = 0; bitmapWidgetBlock < chud->HudWidgets[hudWidgetBlock].BitmapWidgets.Count; bitmapWidgetBlock = bitmapWidgetBlock + 1)
+					{
+						if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C3) // broadcast
+							broadcastIndex = bitmapWidgetBlock;
+						if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C4) // broadcast_available
+							broadcastAvailableIndex = bitmapWidgetBlock;
+						if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C5) // broadcast_ptt_sybmol
+							broadcastPTTIndex = bitmapWidgetBlock;
+						if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C6) // broadcast_no
+							broadcastNoIndex = bitmapWidgetBlock;
+
+						//if everything is found, break early.
+						if (((broadcastIndex != NULL) & (broadcastAvailableIndex != NULL)) & ((broadcastPTTIndex != NULL) & (broadcastNoIndex != NULL)))
+							break;
+					}
+				}
+				if (chud->HudWidgets[hudWidgetBlock].NameStringID == 0x45BF) // speaker_name
+				{
+					speakingPlayerIndex = hudWidgetBlock;
+				}
+				if ((teamBroadcastIndicatorIndex != NULL) & (speakingPlayerIndex != NULL))
+					break;
+			}
+			firstHudUpdate = false;
+		}
+		//Hide all Icons.
+		chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].PlacementData[0].ScaleX = 0;
+		chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastIndex].PlacementData[0].ScaleX = 0;
+		chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastNoIndex].PlacementData[0].ScaleX = 0;
+		chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastPTTIndex].PlacementData[0].ScaleX = 0;
+
+		chud->HudWidgets[speakingPlayerIndex].PlacementData[0].ScaleX = 0;
+
+		//Show the correct Icon.
+		//To remove hardcoded scale values, we could store these default scales earlier by reading them on first update. I'm gonna leave them for now.
+		switch (micState)
+		{
+		case VoIPIcon::Available:
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].PlacementData[0].ScaleX = 1;
+			break;
+		case VoIPIcon::Speaking:
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastIndex].PlacementData[0].ScaleX = 0.75; //I think saber gave this one a new icon and scaled it down...
+			break;
+		case VoIPIcon::Unavailable:
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastNoIndex].PlacementData[0].ScaleX = 1;
+			break;
+		case VoIPIcon::PushToTalk:
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastPTTIndex].PlacementData[0].ScaleX = 1;
+			break;
+		}
+
+		if (someoneSpeaking)
+			chud->HudWidgets[speakingPlayerIndex].PlacementData[0].ScaleX = 1;
 	}
 }

--- a/src/Patches/Ui.hpp
+++ b/src/Patches/Ui.hpp
@@ -25,5 +25,19 @@ namespace Patches
 		extern int DialogFlags;
 		extern unsigned int DialogParentStringId;
 		extern void* UIData;
+
+		enum VoIPIcon
+		{
+			Unavailable,
+			Available,
+			PushToTalk,
+			Speaking
+		};
+
+		void ToggleSpeaker(bool);
+		void SetSpeakingPlayer(std::string);
+
+		void SetVoIPIcon(Patches::Ui::VoIPIcon);
+		void UpdateVoIPIcons();
 	}
 }

--- a/src/Patches/Ui.hpp
+++ b/src/Patches/Ui.hpp
@@ -34,10 +34,10 @@ namespace Patches
 			Speaking
 		};
 
-		void ToggleSpeaker(bool);
-		void SetSpeakingPlayer(std::string);
+		void ToggleSpeaker(bool newSomeoneSpeaking);
+		void SetSpeakingPlayer(std::string speakingPlayer);
 
-		void SetVoIPIcon(Patches::Ui::VoIPIcon);
+		void SetVoIPIcon(VoIPIcon newIcon);
 		void UpdateVoIPIcons();
 	}
 }


### PR DESCRIPTION
## Update
I refactored the SetSpeakerName method a little to greatly improve performance. Now instead of looping through all strings in 0x12c2 and storing that data multiple times, the string is converted into bytes and the old speaking_player string is replaced directly. I've just tested this and to reduce commits I'm going to create this pull request again.

### Proposed changes in this pull request:

1. Added some methods to the Ui Patch to restore functionality to the voice chat HUD widgets.
2. Added a tag definition for unic (multilingual unicode string list).

### Why should this pull request be merged?
This adds a little feedback to the user, they can easily see if they're talking, if they can or cannot talk and if push to talk is enabled. Currently the icons are in the game, but they're attached to halo 3's voice chat state data which is not functional. They're going to waste. Also, the old speaking player text was removed and has not yet been replaced, this is an option.

### Have you tested this on your own and/or in a game with other people?
I've only tested the patch alone, with some debug commands as it is not currently attached to teamspeak. When it's actually being used, it'll probably need some more testing and refactoring might be necessary too. This is the first time I've used C++ so things could definitely be improved.

### Required Tag Changes
- Added a "speaking_player" string to display who's speaking on the HUD.
- Removed broken statedata from voice chat icons.
- Removed statedata from speaking player text.
- Replace string on speaking player text.

These tag changes have been included in further detail with a TagTool script in the attached ZIP file.
[VoIP Icons Tag Changes.zip](https://github.com/ElDewrito/ElDorito/files/448457/VoIP.Icons.Tag.Changes.zip)

## Other Information
To change the "speaking_player" string I needed to add a tag definition for unic. This could be refactored and isn't fully mapped out, but it's functional and not doing any harm. In general, changing the string is probably the roughest area due to my lack of experience with C++. I imagine that this could be refactored to improve performance, at the very least with use of boost. This method is more of a draft and while it does function should probably be rewritten when the patch is actually attached to teamspeak.

Without the other HUD tag modifications, the VoIP icons are above consumables. Saber put them there, they have been moved since Halo 3, and with the updated tags they'll look better. But if you're using old tags, they might look a little odd.

### Previews
During testing I used commands to control the HUD.
[Changing the speaking player string]
(http://i.imgur.com/3DYM6rY.jpg)
[Changing the displayed icon]
(http://a.pomf.cat/uljlxn.mp4)

It's worth noting that these were captured during testing and any mistakes have since been fixed. There's also a method to toggle the text for the speaking player, (if nobody is talking, hide it) I just don't have any footage of this.