### PR TITLE
Added Voice Chat HUD Widgets to the UI Patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ add_library(ElDorito SHARED
     src/Blam/Tags/Sounds/Noise.hpp
     src/Blam/Tags/UI/ChudDefinition.hpp
     src/Blam/Tags/UI/ChudGlobalsDefinition.hpp
+    src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
     src/Console.cpp
     src/Console.hpp
     src/DirectXHook.cpp

--- a/src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
+++ b/src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <cstdint>
+#include "../Tags.hpp"
+#include "../../Text/StringID.hpp"
+#include <string>
+
+namespace Blam
+{
+	namespace Tags
+	{
+		namespace UI
+		{
+			using Blam::Tags::TagBlock;
+			using Blam::Tags::TagData;
+			using Blam::Tags::TagGroup;
+			using Blam::Tags::TagReference;
+			using Blam::Text::StringID;
+
+			struct MultilingualUnicodeStringList : TagGroup<'unic'>
+			{
+				struct LocalizedString;
+
+				TagBlock<LocalizedString> Strings;
+			    TagData<int8_t> Data;
+
+				struct LocalizedString
+				{
+					StringID StringID;
+					int32_t Unknown[8]; //This stuff is actually known, just not mapped out. There's a string in here.
+					int32_t Offsets[12];
+				};
+				TAG_STRUCT_SIZE_ASSERT(LocalizedString, 0x54);
+			};
+		}
+	}
+}

--- a/src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
+++ b/src/Blam/Tags/UI/MultilingualUnicodeStringList.hpp
@@ -26,7 +26,7 @@ namespace Blam
 				struct LocalizedString
 				{
 					StringID StringID;
-					int32_t Unknown[8]; //This stuff is actually known, just not mapped out. There's a string in here.
+					char StringIDStr[32]; //This should really be stored as a string.
 					int32_t Offsets[12];
 				};
 				TAG_STRUCT_SIZE_ASSERT(LocalizedString, 0x54);

--- a/src/ElPatches.cpp
+++ b/src/ElPatches.cpp
@@ -79,6 +79,7 @@ namespace Patches
 		Armor::ApplyAfterTagsLoaded();
 		Armor::RefreshUiPlayer();
 		Ui::ApplyUIResolution();
+		Ui::ApplyAfterTagsLoaded();
 	}
 
 	void Tick()

--- a/src/Patches/Ui.cpp
+++ b/src/Patches/Ui.cpp
@@ -9,6 +9,12 @@
 #include "../Blam/BlamNetwork.hpp"
 #include "../Modules/ModuleGraphics.hpp"
 #include "../Web/Ui/ScreenLayer.hpp"
+#include "../Blam/Tags/UI/MultilingualUnicodeStringList.hpp"
+#include <iostream>
+#include <string>
+#include <locale>
+#include <codecvt>
+#include <iomanip>
 
 using namespace Patches::Ui;
 
@@ -30,6 +36,9 @@ namespace
 	std::vector<CreateWindowCallback> createWindowCallbacks;
 
 	Patch unused; // for some reason a patch field is needed here (on release builds) otherwise the game crashes while loading map/game variants, wtf?
+
+	VoIPIcon micState = VoIPIcon::Unavailable;
+	bool someoneSpeaking;
 }
 
 namespace Patches
@@ -71,6 +80,163 @@ namespace Patches
 		void OnCreateWindow(CreateWindowCallback callback)
 		{
 			createWindowCallbacks.push_back(callback);
+		}
+
+		void SetVoIPIcon(VoIPIcon newIcon)
+		{
+			micState = newIcon;
+			UpdateVoIPIcons();
+		}
+
+		void ToggleSpeaker(bool newSomeoneSpeaking)
+		{
+			someoneSpeaking = newSomeoneSpeaking;
+			UpdateVoIPIcons();
+		}
+
+		bool firstStringUpdate = true;
+		int speakingPlayerOffset; //The offset of speaker_name in memory.
+		static const char* const hex = "0123456789ABCDEF";
+		std::stringstream hexStringStream;
+
+		void SetSpeakingPlayer(std::string speakingPlayer)
+		{
+			//This method could use some refactoring, and performance could be improved I think.
+			using Blam::Tags::TagInstance;
+			using Blam::Tags::UI::MultilingualUnicodeStringList;
+
+			if (speakingPlayer.length() > 15) // player names are limited to 15 anyway.
+				return;
+
+			auto *unic = Blam::Tags::TagInstance(0x12c2).GetDefinition<Blam::Tags::UI::MultilingualUnicodeStringList>();
+
+			if (firstStringUpdate)
+			{
+				//go through string blocks backwards to find speaking_player, as it should be at the end.
+				for (int stringBlockIndex = unic->Strings.Count - 1; stringBlockIndex > -1; --stringBlockIndex)
+					if (unic->Strings[stringBlockIndex].StringID == 0x9202) // speaking_player
+					{
+						speakingPlayerOffset = unic->Strings[stringBlockIndex].Offsets[0]; //read the english offset,
+						break;
+					}
+
+				//If the speaking_player string cannot be found, RIP. This shouldn't happen unless tags don't have correct modifications.
+				if (speakingPlayerOffset == NULL)
+					throw nullptr;
+
+				firstStringUpdate = false;
+			}
+
+			std::string newHudMessagesStrings;
+			newHudMessagesStrings.reserve(30);
+
+			for (size_t i = 0; i < speakingPlayer.length(); ++i)
+			{
+				const unsigned char c = speakingPlayer[i];
+				newHudMessagesStrings.push_back(hex[c >> 4]);
+				newHudMessagesStrings.push_back(hex[c & 15]);
+			}
+
+			//if the speaker name is less than 15 characters, fill the rest of the string with 0.
+			if (speakingPlayer.length() < (size_t)15)
+				for (int i = speakingPlayer.length() * 2; i < 30; ++i)
+					newHudMessagesStrings.push_back('0');
+
+			//Now convert the hex string to a byte array and poke!
+			hexStringStream >> std::hex;
+			for (size_t strIndex = 0, dataIndex = 0; strIndex < (size_t)newHudMessagesStrings.length(); ++dataIndex)
+			{
+				// Read out and convert the string two characters at a time
+				const char tmpStr[3] = { newHudMessagesStrings[strIndex++], newHudMessagesStrings[strIndex++], 0 };
+
+				// Reset and fill the string stream
+				hexStringStream.clear();
+				hexStringStream.str(tmpStr);
+
+				// Do the conversion
+				int tmpValue = 0;
+				hexStringStream >> tmpValue;
+				unic->Data.Elements[dataIndex + speakingPlayerOffset] = static_cast<unsigned char>(tmpValue);
+			}
+		}
+
+		bool firstHudUpdate = true;
+		int teamBroadcastIndicatorIndex = 0; //Hud Widget containing Icons.
+		int broadcastAvailableIndex = 0; //Can Talk Icon
+		int broadcastIndex = 0; //Talking Icon.
+		int broadcastPTTIndex = 0; //Push To Talk Icon
+		int broadcastNoIndex = 0; //Can't Talk Icon
+		int speakingPlayerIndex = 0; //Hud Widget Containing Speaker.
+
+		void UpdateVoIPIcons()
+		{
+			using Blam::Tags::TagInstance;
+			using Blam::Tags::UI::ChudDefinition;
+
+			auto *chud = Blam::Tags::TagInstance(0x12BD).GetDefinition<Blam::Tags::UI::ChudDefinition>();
+
+			//If it's the first time updating the HUD, find the tagblock indexes.
+			if (firstHudUpdate)
+			{
+				for (int hudWidgetBlock = 0; hudWidgetBlock < chud->HudWidgets.Count; hudWidgetBlock = hudWidgetBlock + 1)//New to the syntax, increment operator might be better. -Alex.
+				{
+					if (chud->HudWidgets[hudWidgetBlock].NameStringID == 0x45C2) // team_broadcast_indicator
+					{
+						teamBroadcastIndicatorIndex = hudWidgetBlock;
+
+						for (int bitmapWidgetBlock = 0; bitmapWidgetBlock < chud->HudWidgets[hudWidgetBlock].BitmapWidgets.Count; bitmapWidgetBlock = bitmapWidgetBlock + 1)
+						{
+							if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C3) // broadcast
+								broadcastIndex = bitmapWidgetBlock;
+							if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C4) // broadcast_available
+								broadcastAvailableIndex = bitmapWidgetBlock;
+							if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C5) // broadcast_ptt_sybmol
+								broadcastPTTIndex = bitmapWidgetBlock;
+							if (chud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C6) // broadcast_no
+								broadcastNoIndex = bitmapWidgetBlock;
+
+							//if everything is found, break early.
+							if (((broadcastIndex != NULL) & (broadcastAvailableIndex != NULL)) & ((broadcastPTTIndex != NULL) & (broadcastNoIndex != NULL)))
+								break;
+						}
+					}
+					if (chud->HudWidgets[hudWidgetBlock].NameStringID == 0x45BF) // speaker_name
+					{
+						speakingPlayerIndex = hudWidgetBlock;
+					}
+					if ((teamBroadcastIndicatorIndex != NULL) & (speakingPlayerIndex != NULL))
+						break;
+				}
+				firstHudUpdate = false;
+			}
+			//Hide all Icons.
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].PlacementData[0].ScaleX = 0;
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastIndex].PlacementData[0].ScaleX = 0;
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastNoIndex].PlacementData[0].ScaleX = 0;
+			chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastPTTIndex].PlacementData[0].ScaleX = 0;
+
+			chud->HudWidgets[speakingPlayerIndex].PlacementData[0].ScaleX = 0;
+
+			//Show the correct Icon.
+			//To remove hardcoded scale values, we could store these default scales earlier by reading them on first update. I'm gonna leave them for now.
+			switch (micState)
+			{
+			case VoIPIcon::Available:
+				chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].PlacementData[0].ScaleX = 1;
+				break;
+			case VoIPIcon::Speaking:
+				chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastIndex].PlacementData[0].ScaleX = 0.75; //I think saber gave this one a new icon and scaled it down...
+				break;
+			case VoIPIcon::Unavailable:
+				chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastNoIndex].PlacementData[0].ScaleX = 1;
+				break;
+			case VoIPIcon::PushToTalk:
+				chud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastPTTIndex].PlacementData[0].ScaleX = 1;
+				break;
+			}
+
+			if (someoneSpeaking)
+				chud->HudWidgets[speakingPlayerIndex].PlacementData[0].ScaleX = 1;
 		}
 
 		void ApplyAll()

--- a/src/Patches/Ui.hpp
+++ b/src/Patches/Ui.hpp
@@ -40,5 +40,6 @@ namespace Patches
 
 		void SetVoiceChatIcon(VoiceChatIcon newIcon);
 		void UpdateVoiceChatHUD();
+		void ApplyAfterTagsLoaded();
 	}
 }

--- a/src/Patches/Ui.hpp
+++ b/src/Patches/Ui.hpp
@@ -26,18 +26,19 @@ namespace Patches
 		extern unsigned int DialogParentStringId;
 		extern void* UIData;
 
-		enum VoIPIcon
+		enum VoiceChatIcon
 		{
-			Unavailable,
+			None,
+			Speaking,
 			Available,
-			PushToTalk,
-			Speaking
+			Unavailable,
+			PushToTalk
 		};
 
 		void ToggleSpeaker(bool newSomeoneSpeaking);
 		void SetSpeakingPlayer(std::string speakingPlayer);
 
-		void SetVoIPIcon(VoIPIcon newIcon);
-		void UpdateVoIPIcons();
+		void SetVoIPIcon(VoiceChatIcon newIcon);
+		void UpdateVoiceChatHUD();
 	}
 }

--- a/src/Patches/Ui.hpp
+++ b/src/Patches/Ui.hpp
@@ -25,5 +25,19 @@ namespace Patches
 		extern int DialogFlags;
 		extern unsigned int DialogParentStringId;
 		extern void* UIData;
+
+		enum VoIPIcon
+		{
+			Unavailable,
+			Available,
+			PushToTalk,
+			Speaking
+		};
+
+		void ToggleSpeaker(bool newSomeoneSpeaking);
+		void SetSpeakingPlayer(std::string speakingPlayer);
+
+		void SetVoIPIcon(VoIPIcon newIcon);
+		void UpdateVoIPIcons();
 	}
 }

--- a/src/Patches/Ui.hpp
+++ b/src/Patches/Ui.hpp
@@ -35,10 +35,10 @@ namespace Patches
 			PushToTalk
 		};
 
-		void ToggleSpeaker(bool newSomeoneSpeaking);
+		void ToggleSpeakingPlayer(bool newSomeoneSpeaking);
 		void SetSpeakingPlayer(std::string speakingPlayer);
 
-		void SetVoIPIcon(VoiceChatIcon newIcon);
+		void SetVoiceChatIcon(VoiceChatIcon newIcon);
 		void UpdateVoiceChatHUD();
 	}
 }


### PR DESCRIPTION
## Update (Commit 4)

Today I have been messing around with attaching this patch to the current voice chat system.
I realised that some command integration might be necessary, for example the voip.pushtotalk command might need to change the voice chat icon to push to talk, or just available. Also, if voip.enabled is toggled, the icon needs to change between none and available.
The problem is, since commands are all called at launch, they can cause the patch to run before tags have been loaded. This is something I've encountered before in testing so I just added a boolean value that can be used to break out of functions before tags are loaded.
## Update (Commit 3)
- Added [the broadcasting icon on the radar](http://i.imgur.com/r6SpOds.png).
  - This requires a couple tag changes, I've updated the zip file below.
- Removed some handling for modded tags.
  - It was getting a little too big, and it's not really necessary.
- General Refactoring
## Update (Commit 2)
- Added a new method of toggling the icons, which triggers the open/close animations.
- Added more support for modded scoreboard tags.
- Added a "None" option to the voice chat icons enum,
- Reduced tag changes.
- Removed some hardcoded values.
- General Refactoring.
- [Test Build (with commands, requires tag changes.)](https://github.com/ElDewrito/ElDorito/files/451012/VoipIconsTest.zip)
### Proposed changes in this pull request:
1. Added some methods to the Ui Patch to restore functionality to the voice chat HUD widgets.
2. Added a tag definition for unic (multilingual unicode string list).
### Why should this pull request be merged?

This adds a little feedback to the user, they can easily see if they're talking, if they can or cannot talk and if push to talk is enabled. Currently the icons are in the game, but they're attached to halo 3's voice chat state data which is not functional. They're going to waste. Also, the old speaking player text was removed and has not yet been replaced, this is an option.
### Have you tested this on your own and/or in a game with other people?

This patch has most recently been tested backported onto 0.5.1.1. I've tested it in large lobbies and from what I have seen it performs smoothly.

Each commit has been tested with commands both alone and multi-player on 0.5.1.1 and various other modded tags with performance in mind. 
### Required Tag Changes
- Added a "speaking_player" string to display who's speaking on the HUD.
- Re-scaled and re-positioned the broadcasting icon on the radar. (Testing on 0.5.1.1 didn't require this and I have no idea why.)

These tag changes have been included in further detail with a Tag Tool script in the attached ZIP file.
[VoIP Icons Tag Changes.zip](https://github.com/ElDewrito/ElDorito/files/452906/VoIP.Icons.Tag.Changes.zip)
[Halo Online HUD Fixup Mod (some of the HUD changes coming in 0.6)](https://github.com/Alex-231/H-O-HUD-Fixup)
### Information for Tag Mods

The patch requites HUD widgets for voice chat feedback present in the stock tags, or it will disable itself.
The text widget that displays the name of the speaking player will be updated with the new speaking_player string automatically.
### Previews

During testing I used commands to control the HUD.
[A preview of how the HUD would function with voice chat](http://a.pomf.cat/zxfzlw.mp4)
[Changing the speaking player string](http://i.imgur.com/3DYM6rY.jpg)
[Changing the displayed icon](http://a.pomf.cat/uljlxn.mp4)
