### PR TITLE
Fix spectate

### DIFF
--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -137,6 +137,9 @@ namespace Patches
 			Pointer::Base(0x1A31A4).Write<uint8_t>(0xEB);
 			Hook(0x1A3267, GrenadeLoadoutHook).Apply();
 
+			// fix spectating
+			Patch::NopFill(Pointer::Base(0x192FFD), 6);
+
 			// Remove exception handlers
 			/*Patch::NopFill(Pointer::Base(0x2EA2B), 6);
 			Patch::NopFill(Pointer::Base(0x2EC10), 6);


### PR DESCRIPTION
### Proposed changes in this pull request:

Fix spectate

### Why should this pull request be merged?
Spectating.

### Have you tested this on your own and/or in a game with other people?
Tested by two different people, online, with 16 players.

### Information
By default, the controls to switch players are: A/D on the keyboard; UP/DOWN on the DPAD, however, this can be easily changed. See: **sub_592F90**.  For those wanting to make a UI: 0x198 of the unit object is the player datum index. It's also cached in multiple places globally.

```cpp
/*
 .text:00592A80
 * direction: 1 or -1 (next or previous player)
 * returns the player datum index
*/
int __cdecl Game_Spectating_GetNextPlayer(int unkPlayerIndex, int a2, int thisPlayerIndex, int direction, char a5, char a6, char a7, int *a8)
```
