### PR TITLE
Prevent hf2p services from being registered

### DIFF
--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -62,6 +62,9 @@ namespace Patches
 			Patch(0x43731A, { 0xEB, 0x0E }).Apply();
 			Patch(0x4373AD, { 0xEB, 0x03 }).Apply();
 
+			// prevent hf2p services from being registered
+			Patch(0x003B8810, { 0xC3 }).Apply();
+
 			// Remove preferences.dat hash check
 			Patch::NopFill(Pointer::Base(0x10C99A), 0x6);
 


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Prevent hf2p services from being registered

### Why should this pull request be merged?
Eldorado is still calling home - wasting cpu cycles

### Have you tested this on your own and/or in a game with other people?
It seems fine, but it's going to need some more testing

### Information
dword_4FE72E8 ; Service table
.text:007B8810 ; void __cdecl Game_RegisterHf2pService(void *service)

Example of some of the services identified by RTTI:

- hf2p::c_polly<BackEnd::IMessagingService
- hf2p::c_polly<BackEnd::IGameStatisticsService
- hf2p::c_polly<BackEnd::IHeartbeatService
- hf2p::c_polly<BackEnd::IEndpointsDispatcherService


https://www.youtube.com/watch?v=sfzmzOwPEG0

