### PR TITLE
Corrected number of teams listed in server json

### DIFF
--- a/ElDorito/Source/Patches/Network.cpp
+++ b/ElDorito/Source/Patches/Network.cpp
@@ -222,7 +222,7 @@ namespace Patches
 							writer.Key("teamScores");
 							writer.StartArray();
 							uint32_t* scores = &Pointer(0x01879DA8).Read<uint32_t>();
-							for (int t = 0; t < 10; t++)
+							for (int t = 0; t < 8; t++)
 							{
 								writer.Int(scores[t]);
 							}


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Change the number of teams listed in the server json from 10 to 8

### Why should this pull request be merged?
There are only 8 teams that can be selected in the game: red, blue, green, orange, purple, gold, brown, and pink. Without this change the json reads "teamScores": [0, -1, -1, -1, -1, -1, -1, -1, 0, 0]
when it should read "teamScores": [0, -1, -1, -1, -1, -1, -1, -1]. The last two 0's are non existent teams and the -1's are uninitialized teams, the first 0 is red teams score, which is initialized as I am on that team.
### Have you tested this on your own and/or in a game with other people?
Works ingame for me, and does not cause any issues with infection, as infection is treated as being free for all.