### PR TITLE
Short optimization to only attempt grenade drop on bipeds

### DIFF
--- a/ElDorito/Source/Patches/Equipment.cpp
+++ b/ElDorito/Source/Patches/Equipment.cpp
@@ -514,7 +514,7 @@ namespace
 		assert(objects);
 
 		auto unitObjectDatum = objects->Get(unitObjectIndex);
-		if (!unitObjectDatum || !unitObjectDatum->Data)
+		if (!unitObjectDatum || !unitObjectDatum->Data || unitObjectDatum->Type != Blam::Objects::eObjectTypeBiped)
 			return;
 
 		auto unitObjectPtr = Pointer(unitObjectDatum->Data);


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Only run grenade drop on bipeds

### Why should this pull request be merged?
Short optimization. 

### Have you tested this on your own and/or in a game with other people?
Yes.