### PR TITLE
Voting - Load MaxTeamSize variable from voting.json

### DIFF
--- a/ElDorito/Source/Server/VotingSystem.cpp
+++ b/ElDorito/Source/Server/VotingSystem.cpp
@@ -255,6 +255,7 @@ namespace Server
 			Modules::CommandMap::Instance().ExecuteCommand("Game.GameType \"" + winningOption.haloType.typeName + "\"");
 			Modules::CommandMap::Instance().ExecuteCommand("Game.Map \"" + winningOption.haloMap.mapName + "\"");
 			Modules::CommandMap::Instance().ExecuteCommand("Server.SprintEnabled " + winningOption.haloType.SprintEnabled);
+			Modules::CommandMap::Instance().ExecuteCommand("Server.MaxTeamSize " + winningOption.haloType.MaxTeamSize);
 
 			if (Modules::ModuleServer::Instance().VarServerTeamShuffleEnabled->ValueInt == 1)
 				Modules::CommandMap::Instance().ExecuteCommand("Server.ShuffleTeams");
@@ -512,6 +513,8 @@ namespace Server
 					HaloType ht(c["typeName"].GetString(), c["displayName"].GetString());
 					if (c.HasMember("SprintEnabled"))
 						ht.SprintEnabled = c["SprintEnabled"].GetString();
+					if (c.HasMember("MaxTeamSize"))
+						ht.MaxTeamSize = c["MaxTeamSize"].GetString();
 					if (c.HasMember("SpecificMaps"))
 					{
 						const rapidjson::Value& smaps = c["SpecificMaps"];

--- a/ElDorito/Source/Server/VotingSystem.hpp
+++ b/ElDorito/Source/Server/VotingSystem.hpp
@@ -54,11 +54,13 @@ namespace Server
 			std::string typeName;
 			std::string typeDisplayName;
 			std::string SprintEnabled;
+			std::string MaxTeamSize;
 			HaloType(){}
 			HaloType(std::string t, std::string dn) {
 				typeName = t;
 				typeDisplayName = dn;
 				SprintEnabled = "0";
+				MaxTeamSize = "8";
 			}
 
 		};

--- a/dist/Voting.json
+++ b/dist/Voting.json
@@ -45,12 +45,14 @@
       {  
          "displayName":"Team King",
          "typeName":"Team Crazy King",
-         "SprintEnabled":"0"
+         "SprintEnabled":"0",
+		 "MaxTeamSize":"8"
       },
 	  {  
          "displayName":"Team SWAT",
          "typeName":"Team SWAT",
          "SprintEnabled":"0",
+		 "MaxTeamSize":"8",
 		  "SpecificMaps":[  
             {  
                "displayName":"Valhalla",
@@ -77,32 +79,38 @@
       {  
          "displayName":"Team Snipers",
          "typeName":"Team Snipers",
-         "SprintEnabled":"0" 
+         "SprintEnabled":"0",
+		 "MaxTeamSize":"8"
       },
       {
          "displayName":"Team BRs",
          "typeName":"Team BRs",
-         "SprintEnabled":"0"
+         "SprintEnabled":"0",
+		 "MaxTeamSize":"8"
       },
       {  
          "displayName":"Team BRs",
          "typeName":"Team BRs",
-         "SprintEnabled":"0"
+         "SprintEnabled":"0",
+		 "MaxTeamSize":"8"
       },
       {  
          "displayName":"Team DMRs",
          "typeName":"Team DMRs",
-         "SprintEnabled":"0"
+         "SprintEnabled":"0",
+		 "MaxTeamSize":"8"
       },
       {  
          "displayName":"Team Fiesta",
          "typeName":"Team Fiesta",
-         "SprintEnabled":"0"
+         "SprintEnabled":"0",
+		 "MaxTeamSize":"8"
       },
       {  
          "displayName":"Multi Flag",
          "typeName":"Team CTF",
          "SprintEnabled":"0",
+		 "MaxTeamSize":"8",
 		 "SpecificMaps":[  
             {  
                "displayName":"Sandtrap",
@@ -134,6 +142,7 @@
          "displayName":"FFA Oddball",
          "typeName":"FFA Oddball",
          "SprintEnabled":"0",
+		 "MaxTeamSize":"8",
 		 "SpecificMaps": [  
 		  {  
 			 "displayName":"Standoff",

--- a/dist/Voting.json
+++ b/dist/Voting.json
@@ -1,186 +1,185 @@
-{  
-   "Maps":[  
-     {  
-         "displayName":"Standoff",
-         "mapName":"Standoff (TS)"
-      },
-      {  
-         "displayName":"Sandtrap",
-         "mapName":"Sandtrap (TS)"
-      },
-	  {  
-         "displayName":"Icebox",
-         "mapName":"Turf (TS)"
-      },
-      {  
-         "displayName":"Narrows",
-         "mapName":"Narrows (TS)"
-      },
-      {  
-         "displayName":"High Ground",
-         "mapName":"HighGroundTS"
-      },
-      {  
-         "displayName":"Last Resort",
-         "mapName":"LastResortTS"
-      },
-      {  
-         "displayName":"Valhalla",
-         "mapName":"Valhalla (FS)"
-      },
-	  {  
-         "displayName":"The Pit",
-         "mapName":"The Pit (TS)"
-      },
-	  {  
-         "displayName":"Guardian",
-         "mapName":"Guardian (TS)"
-      },
-      {  
-         "displayName":"Diamondback",
-         "mapName":"DiamondbackFS"
-      }
-   ],
-   "Types":[  
-      {  
-         "displayName":"Team King",
-         "typeName":"Team Crazy King",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8"
-      },
-	  {  
-         "displayName":"Team SWAT",
-         "typeName":"Team SWAT",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8",
-		  "SpecificMaps":[  
-            {  
-               "displayName":"Valhalla",
-               "mapName":"Valhalla (Swat)"
-            },
-            { 
-               "displayName":"Standoff",
-               "mapName":"Standoff (Swat)"
-            },
-            {  
-               "displayName":"Last Resort",
-               "mapName":"LastResortSwat"
-            },
-            {  
-               "displayName":"Diamondback",
-               "mapName":"Diamondback (S)"
-            },
-			{  
-               "displayName":"High Ground",
-               "mapName":"HighGroundSwat"
-            }
-         ]
-      },
-      {  
-         "displayName":"Team Snipers",
-         "typeName":"Team Snipers",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8"
-      },
-      {
-         "displayName":"Team BRs",
-         "typeName":"Team BRs",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8"
-      },
-      {  
-         "displayName":"Team BRs",
-         "typeName":"Team BRs",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8"
-      },
-      {  
-         "displayName":"Team DMRs",
-         "typeName":"Team DMRs",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8"
-      },
-      {  
-         "displayName":"Team Fiesta",
-         "typeName":"Team Fiesta",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8"
-      },
-      {  
-         "displayName":"Multi Flag",
-         "typeName":"Team CTF",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8",
-		 "SpecificMaps":[  
-            {  
-               "displayName":"Sandtrap",
-               "mapName":"Sandtrap (Obj)"
-            },
-            {  
-               "displayName":"Valhalla",
-               "mapName":"Valhalla (FS)"
-            },
-            {  
-               "displayName":"Standoff",
-               "mapName":"Standoff (Obj)"
-            },
-            {  
-               "displayName":"Last Resort",
-               "mapName":"LastResortCTF"
-            },
-            {  
-               "displayName":"Diamondback",
-               "mapName":"DiamondbackFS"
-            },
-			{  
-               "displayName":"High Ground",
-               "mapName":"HighGroundCTF"
-            }
-         ]
-      },
-      {  
-         "displayName":"FFA Oddball",
-         "typeName":"FFA Oddball",
-         "SprintEnabled":"0",
-		 "MaxTeamSize":"8",
-		 "SpecificMaps": [  
-		  {  
-			 "displayName":"Standoff",
-			 "mapName":"Standoff (H3)"
-		  },
-		  {  
-			 "displayName":"The Pit",
-			 "mapName":"The Pit (H3)"
-		  },
-		  {  
-			 "displayName":"Sandtrap",
-			 "mapName":"Sandtrap (H3)"
-		  },
-		  {  
-			 "displayName":"Narrows",
-			 "mapName":"Narrows(H3)"
-		  },
-		  {  
-			 "displayName":"High Ground",
-			 "mapName":"High Ground(H3)"
-		  },
-		  {  
-			 "displayName":"Last Resort",
-			 "mapName":"Last Resort(H3)"
-		  },
-		  {  
-			 "displayName":"Valhalla",
-			 "mapName":"Valhalla (H3)"
-		  },
-		  {  
-			 "displayName":"Diamondback",
-			 "mapName":"Avalanche"
-		  },
-		  {  
-			 "displayName":"Guardian",
-			 "mapName":"Guardian (H3)"
-		  }
-	   ]
-      }
-   ]
+{
+  "Maps": [
+    {
+      "displayName": "Standoff",
+      "mapName": "Standoff (TS)"
+    },
+    {
+      "displayName": "Sandtrap",
+      "mapName": "Sandtrap (TS)"
+    },
+    {
+      "displayName": "Icebox",
+      "mapName": "Turf (TS)"
+    },
+    {
+      "displayName": "Narrows",
+      "mapName": "Narrows (TS)"
+    },
+    {
+      "displayName": "High Ground",
+      "mapName": "HighGroundTS"
+    },
+    {
+      "displayName": "Last Resort",
+      "mapName": "LastResortTS"
+    },
+    {
+      "displayName": "Valhalla",
+      "mapName": "Valhalla (FS)"
+    },
+    {
+      "displayName": "The Pit",
+      "mapName": "The Pit (TS)"
+    },
+    {
+      "displayName": "Guardian",
+      "mapName": "Guardian (TS)"
+    },
+    {
+      "displayName": "Diamondback",
+      "mapName": "DiamondbackFS"
+    }
+  ],
+  "Types": [
+    {
+      "displayName": "Team King",
+      "typeName": "Team Crazy King",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8"
+    },
+    {
+      "displayName": "Team SWAT",
+      "typeName": "Team SWAT",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8",
+      "SpecificMaps": [
+        {
+          "displayName": "Valhalla",
+          "mapName": "Valhalla (Swat)"
+        },
+        {
+          "displayName": "Standoff",
+          "mapName": "Standoff (Swat)"
+        },
+        {
+          "displayName": "Last Resort",
+          "mapName": "LastResortSwat"
+        },
+        {
+          "displayName": "Diamondback",
+          "mapName": "Diamondback (S)"
+        },
+        {
+          "displayName": "High Ground",
+          "mapName": "HighGroundSwat"
+        }
+      ]
+    },
+    {
+      "displayName": "Team Snipers",
+      "typeName": "Team Snipers",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8"
+    },
+    {
+      "displayName": "Team BRs",
+      "typeName": "Team BRs",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8"
+    },
+    {
+      "displayName": "Team BRs",
+      "typeName": "Team BRs",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8"
+    },
+    {
+      "displayName": "Team DMRs",
+      "typeName": "Team DMRs",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8"
+    },
+    {
+      "displayName": "Team Fiesta",
+      "typeName": "Team Fiesta",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8"
+    },
+    {
+      "displayName": "Multi Flag",
+      "typeName": "Team CTF",
+      "SprintEnabled": "0",
+      "MaxTeamSize": "8",
+      "SpecificMaps": [
+        {
+          "displayName": "Sandtrap",
+          "mapName": "Sandtrap (Obj)"
+        },
+        {
+          "displayName": "Valhalla",
+          "mapName": "Valhalla (FS)"
+        },
+        {
+          "displayName": "Standoff",
+          "mapName": "Standoff (Obj)"
+        },
+        {
+          "displayName": "Last Resort",
+          "mapName": "LastResortCTF"
+        },
+        {
+          "displayName": "Diamondback",
+          "mapName": "DiamondbackFS"
+        },
+        {
+          "displayName": "High Ground",
+          "mapName": "HighGroundCTF"
+        }
+      ]
+    },
+    {
+      "displayName": "FFA Oddball",
+      "typeName": "FFA Oddball",
+      "SprintEnabled": "0",
+      "SpecificMaps": [
+        {
+          "displayName": "Standoff",
+          "mapName": "Standoff (H3)"
+        },
+        {
+          "displayName": "The Pit",
+          "mapName": "The Pit (H3)"
+        },
+        {
+          "displayName": "Sandtrap",
+          "mapName": "Sandtrap (H3)"
+        },
+        {
+          "displayName": "Narrows",
+          "mapName": "Narrows(H3)"
+        },
+        {
+          "displayName": "High Ground",
+          "mapName": "High Ground(H3)"
+        },
+        {
+          "displayName": "Last Resort",
+          "mapName": "Last Resort(H3)"
+        },
+        {
+          "displayName": "Valhalla",
+          "mapName": "Valhalla (H3)"
+        },
+        {
+          "displayName": "Diamondback",
+          "mapName": "Avalanche"
+        },
+        {
+          "displayName": "Guardian",
+          "mapName": "Guardian (H3)"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Allow the voting system to set the MaxTeamSize via the voting.json

2. Add MaxTeamSize to the voting.json

### Why should this pull request be merged?
This change will allow server hosts to play gametypes with more than one team by setting the max team size variable on specific gametypes, setting max team size to 4, will make it have 4 teams with 4 players on each, setting it to 2, will make it have 8 teams with 2 players on each.
### Have you tested this on your own and/or in a game with other people?
Yes, it loaded the MaxTeamSize variable properly from the json.