### PR TITLE
Forge UI - Add save prefab option, move prefab list updater into a function

### DIFF
--- a/dist/mods/ui/web/screens/forge/forge.css
+++ b/dist/mods/ui/web/screens/forge/forge.css
@@ -54,6 +54,17 @@ input[type=range].setting {
     float:right;
 }
 
+.largeInput{
+
+    width:19.50vh;
+
+    margin-top:0.5vh;
+    height:1.9vh;
+    margin-bottom:0vh;
+    float:right;
+}
+
+
 .hasTiny{
     width:19.75vh;
     float:right;

--- a/dist/mods/ui/web/screens/forge/forge.js
+++ b/dist/mods/ui/web/screens/forge/forge.js
@@ -12,11 +12,6 @@ $(document).keyup(function (e) {
     }
 });
 $(document).keydown(function (e) {
-    if(e.keyCode == 84 || e.keyCode == 89){
-        var teamChat = false;
-        if(e.keyCode == 89){ teamChat = true };
-        dew.show("chat", {'captureInput': true, 'teamChat': teamChat});
-    }
     if(e.keyCode == 192 || e.keyCode == 112 || e.keyCode == 223){
         dew.show("console");
     }
@@ -159,16 +154,7 @@ function onControllerDisconnect(){
     $('button img').hide();    
 }
 
-dew.on("show", function(e){
-    dew.command('Settings.Gamepad', {}).then(function(result){
-        if(result == 1){
-            onControllerConnect();
-            hasGP = true;
-        }else{
-            onControllerDisconnect();
-            hasGP = false;
-        }
-    });
+function updatePrefabs(){
     dew.command('Forge.DumpPrefabs', {}).then(function(response){
         $("#forgePrefabs").empty();
         var forgeSelect = document.getElementById('forgePrefabs');
@@ -179,7 +165,20 @@ dew.on("show", function(e){
             opt.value = prefabList[i];
             forgeSelect.appendChild(opt);
         }
+    });   
+}
+
+dew.on("show", function(e){
+    dew.command('Settings.Gamepad', {}).then(function(result){
+        if(result == 1){
+            onControllerConnect();
+            hasGP = true;
+        }else{
+            onControllerDisconnect();
+            hasGP = false;
+        }
     });
+    updatePrefabs();
 });
 
 

--- a/dist/mods/ui/web/screens/forge/index.html
+++ b/dist/mods/ui/web/screens/forge/index.html
@@ -20,8 +20,13 @@
             <input type="text" class="tinySetting" id="fMonitorSpeedText" name="fMonitorSpeed">
             <input type="range" class="setting hasTiny" min="0.1" max="5" step="0.1" id="fMonitorSpeed" oninput="document.querySelector('#fMonitorSpeedText').value = this.value;">
             <br>
-            <label for="forgePrefabs">Forge Prefabs</label>
-            <button class="tinySetting" onclick="dew.command('Forge.LoadPrefab '+$('#forgePrefabs').val());" id="spawnPrefab">Spawn</button>
+			<h3 class="subHeader">Prefabs</h3>
+			<label for="saveforgePrefabs">Save Prefab</label>
+            <button class="tinySetting" onclick="dew.command('Forge.SavePrefab '+$('#fPrefabName').val());document.getElementById('fPrefabName').value= '';updatePrefabs();" id="spawnPrefab">Save</button>
+            <input type="text" class="largeInput" id="fPrefabName">
+            <br>
+            <label for="forgePrefabs">Load Prefab</label>
+            <button class="tinySetting" onclick="dew.command('Forge.LoadPrefab '+$('#forgePrefabs').val());" id="spawnPrefab">Load</button>
             <select id="forgePrefabs" class="setting hasTiny"></select>
             <br>
             <h3 class="subHeader">Object Cloning</h3>


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Add save prefab input and button.

2. Move the prefab list updater into a function so that the list updates when you save a new prefab.

3. Remove chat buttons so text entered into the save prefab input box works properly.

### Why should this pull request be merged?
This will allow you to save a prefab using the HTML forge UI
### Have you tested this on your own and/or in a game with other people?
Yes