### PR TITLE
Settings - Change some tweak names and descriptions to be more accurate

### DIFF
--- a/dist/mods/ui/web/screens/settings/index.html
+++ b/dist/mods/ui/web/screens/settings/index.html
@@ -466,17 +466,17 @@
             <input class="setting" type="checkbox" id="tDisableFog"><br>
             <p class="desc">Removes some of the fog on Reactor which causes FPS drops indoors</p>
             <br>  
-            <label for="tIntelBloomPatch">Intel Bloom Patch</label>
+            <label for="tIntelBloomPatch">Bloom Patch</label>
             <input class="setting" type="checkbox" id="tIntelBloomPatch"><br>
-            <p class="desc">Fixes extreme brightness on sunny maps **Intel integrated GPUs only**</p>
+            <p class="desc">Fixes extreme brightness on sunny maps</p>
             <br>  
             <label for="tDisableWeapOutline">Weapon Outline Removal (by Dany)</label>
             <input class="setting" type="checkbox" id="tDisableWeapOutline"><br>
             <p class="desc">Remove outlines from weapons on the ground</p>
             <br>  
-            <label for="tDisableHeadshotEffect">Disable headshot "ping" sound</label>
+            <label for="tDisableHeadshotEffect">Disable headshot "ping" sound and effect</label>
             <input class="setting" type="checkbox" id="tDisableHeadshotEffect"><br>
-            <p class="desc">Remove the ping sound you hear when killed by a headshot</p>
+            <p class="desc">Remove the effect and ping sound you hear when killed by a headshot</p>
             <br> 
             <label for="tDisableHitmarkers">Disable weapon hitmarkers</label>
             <input class="setting" type="checkbox" id="tDisableHitmarkers"><br>


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Rename Intel Bloom Patch to Bloom Patch 
    http://i.imgur.com/4fvhfb1.png

2. Change the description and name for disable head shot ping, to let user know it also disables the effect.

### Why should this pull request be merged?
People got confused, and things should be accurate

### Have you tested this on your own and/or in a game with other people?
Yes