### PR TITLE
Always skip the Russian language intro.

### DIFF
--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -25,7 +25,7 @@ namespace
 	void LoadLevelHook(uint8_t* data, char n2, int n3, int n4);
 	void GameStartHook();
 	void __fastcall EdgeDropHook(void* thisptr, void* unused, int a2, int a3, int a4, float* a5);
-	char GetBinkVideoPathHook(int p_VideoID, char *p_DestBuf);
+	char GetBinkVideoPathHook(int p_VideoID, char *p_bink_filepath);
 
 	std::vector<Patches::Core::ShutdownCallback> shutdownCallbacks;
 	std::string MapsFolder;
@@ -352,12 +352,16 @@ namespace
 
 	const auto GetBinkVideoPath = reinterpret_cast<char(*)(int, char*)>(0xA99120);
 
-	char GetBinkVideoPathHook(int p_VideoID, char *p_DestBuf)
+	// Returns should the engine attempt to load the bink file
+	char GetBinkVideoPathHook(int p_VideoID, char *p_bink_filepath)
 	{
-		if (Modules::ModuleGame::Instance().VarSkipIntroVideos->ValueInt == 1)
-			// Tell the game that there is no video with that ID
-			return 0;
-
-		return GetBinkVideoPath(p_VideoID, p_DestBuf);
+		// Check if we should display the intros
+		if (Modules::ModuleGame::Instance().VarSkipIntroVideos->ValueInt)
+			return false;
+		// never load the russian langauge intro
+		if (p_VideoID == 3)
+			return false;
+		// Call the orginal function
+		return GetBinkVideoPath(p_VideoID, p_bink_filepath);
 	}
 }


### PR DESCRIPTION
### Proposed changes in this pull request:
Not loading and displaying the Russian language intro (intro.bik)
### Why should this pull request be merged?
0. Loading it wastes time at game startup
1. It's a left over from halo online and iirc it goes over the "story" of the game
2. It's over available in Russian
3. If someone really wants to watch it they can just google it.
### Have you tested this on your own and/or in a game with other people?
Yes, I loaded the game a few times.