### PR TITLE
Allow setting server.lobbytype to any valid type of lobby.

### DIFF
--- a/ElDorito/Source/Modules/ModuleServer.cpp
+++ b/ElDorito/Source/Modules/ModuleServer.cpp
@@ -1194,7 +1194,7 @@ namespace Modules
 
 		VarServerLobbyType = AddVariableInt("LobbyType", "lobbytype", "Changes the lobby type for the server. 0 = Campaign; 1 = Matchmaking; 2 = Multiplayer; 3 = Forge; 4 = Theater;", eCommandFlagsDontUpdateInitial, 2, CommandServerLobbyType);
 		VarServerLobbyType->ValueIntMin = 0;
-		VarServerLobbyType->ValueIntMax = 4;
+		VarServerLobbyType->ValueIntMax = 5;
 
 		VarServerSprintEnabled = AddVariableInt("SprintEnabled", "sprint", "Controls whether sprint is enabled on the server", static_cast<CommandFlags>(eCommandFlagsArchived | eCommandFlagsReplicated), 1);
 		VarServerSprintEnabledClient = AddVariableInt("SprintEnabledClient", "sprint_client", "", eCommandFlagsInternal, 1, SprintEnabledChanged);


### PR DESCRIPTION
### Proposed changes in this pull request:
 Allow setting lobby type to 5
### Why should this pull request be merged?
We allow other lobby types that don't work correctly but don't crash anything so we might as well allow type 5.
### Have you tested this on your own and/or in a game with other people?
yes