### PR TITLE
Don't show the forge legal notice.

### DIFF
--- a/ElDorito/Source/Patches/Forge.cpp
+++ b/ElDorito/Source/Patches/Forge.cpp
@@ -55,6 +55,8 @@ namespace
 
 	std::queue<std::function<void()>> s_SandboxTickCommandQueue;
 	RealVector3D s_GrabOffset;
+
+	bool shown_legal(char unused);
 }
 
 namespace Patches
@@ -86,6 +88,10 @@ namespace Patches
 
 			// enable teleporter volume editing compliments of zedd
 			Patch::NopFill(Pointer::Base(0x6E4796), 0x66);
+
+			Hook(0x70E33B, shown_legal, HookFlags::IsCall).Apply();
+			Hook(0x6EAAD3, shown_legal, HookFlags::IsCall).Apply();
+			Hook(0x6EAA2D, shown_legal, HookFlags::IsCall).Apply();
 
 			Patches::Core::OnGameStart(FixRespawnZones);
 
@@ -632,5 +638,9 @@ namespace
 					GrabSelection(playerIndex);
 			}
 		}
+	}
+	bool shown_legal(char unused)
+	{
+		return true;
 	}
 }


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Don't display the forge legal notice when saving a map variant.

### Why should this pull request be merged?
The legal notice is pointless for ElDewrito since it's just the terms of service for Halo 3 forge.
### Have you tested this on your own and/or in a game with other people?
yes