### PR TITLE
Add commands for setting forge map name and description.

### DIFF
--- a/ElDorito/Source/Modules/ModuleForge.cpp
+++ b/ElDorito/Source/Modules/ModuleForge.cpp
@@ -1,3 +1,5 @@
+#include <locale>
+#include <codecvt>
 #include "ModuleForge.hpp"
 #include "../Patches/Forge.hpp"
 #include "boost\filesystem.hpp"
@@ -120,6 +122,34 @@ namespace
 		returnInfo = buffer.GetString();
 		return true;
 	}
+	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> string_converter;
+	bool CommandSetName(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		if (Arguments.empty())
+		{
+			returnInfo = "expected varient name";
+			return false;
+		}
+
+		std::wstring name = string_converter.from_bytes(Arguments[0]);
+		Patches::Forge::ForgeVariant_Set_Name(name);
+		returnInfo = "Varient name set to " + Arguments[0];
+		return true;
+	}
+
+	bool CommandSetDescription(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		if (Arguments.empty())
+		{
+			returnInfo = "expected varient description";
+			return false;
+		}
+
+		std::string description = Arguments[0];
+		Patches::Forge::ForgeVariant_Set_Description(description);
+		returnInfo = "Varient description set to " + description;
+		return true;
+	}
 }
 
 namespace Modules
@@ -142,5 +172,7 @@ namespace Modules
 		AddCommand("SavePrefab", "forge_prefab_save", "Save prefab to a file", eCommandFlagsNone, CommandSavePrefab);
 		AddCommand("LoadPrefab", "forge_prefab_load", "Load prefab from a file", eCommandFlagsNone, CommandLoadPrefab);
 		AddCommand("DumpPrefabs", "forge_prefab_dump", "Dump a list of saved prefabs in json", eCommandFlagsNone, CommandDumpPrefabs);
+		AddCommand("SetName", "forge_set_name", "Set the name of the current map varient", eCommandFlagsNone, CommandSetName);
+		AddCommand("SetDescription", "forge_set_description", "Set the description that will be used when the current map varrient", eCommandFlagsNone, CommandSetDescription);
 	}
 }

--- a/ElDorito/Source/Patches/Forge.cpp
+++ b/ElDorito/Source/Patches/Forge.cpp
@@ -113,6 +113,24 @@ namespace Patches
 
 			return true;
 		}
+
+		void ForgeVariant_Set_Name(const std::wstring name)
+		{
+			const wchar_t *c_name = name.c_str();
+			static auto get_forge_varient = (void*(*)())(0x583230);
+			void *forge_varient = get_forge_varient();
+
+			static auto Game_ForgeVariant_SetName = (wchar_t*(__thiscall*)(void* thisptr, const wchar_t* name))(0x586570);
+			Game_ForgeVariant_SetName(forge_varient, c_name);
+		}
+
+		void ForgeVariant_Set_Description(const std::string description) {
+			const char *c_description = description.c_str();
+			static auto get_forge_varient = (char*(*)())(0x583230);
+			char *forge_varient = get_forge_varient();
+
+			strncpy(forge_varient + 0x28, c_description, 127);
+		}
 	}
 }
 

--- a/ElDorito/Source/Patches/Forge.hpp
+++ b/ElDorito/Source/Patches/Forge.hpp
@@ -11,5 +11,7 @@ namespace Patches
 
 		bool SavePrefab(const std::string& name, const std::string& path);
 		bool LoadPrefab(const std::string& path);
+		void ForgeVariant_Set_Name(const std::wstring name);
+		void ForgeVariant_Set_Description(const std::string description);
 	}
 }


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Add command for setting forge map description

2. Add command for setting forge map name

### Why should this pull request be merged?
The first command is useful in general since there is no way to do this currently without a hex editor and the second could be helpful for anyone working to replace the in-game menu with HTML.
### Have you tested this on your own and/or in a game with other people?
yes