### PR TITLE
Remove unneeded checks

### DIFF
--- a/ElDorito/Source/Patches/Network.cpp
+++ b/ElDorito/Source/Patches/Network.cpp
@@ -480,16 +480,12 @@ namespace Patches
 			bindAddr.sin_addr.s_addr = htonl(INADDR_ANY);
 
 			unsigned long port = Modules::ModuleServer::Instance().VarServerPort->ValueInt;
-			if (port == Pointer(0x1860454).Read<uint32_t>()) // make sure port isn't the same as game port
-				port++;
 			bindAddr.sin_port = htons((u_short)port);
 
 			// open our listener socket
 			while (bind(infoSocket, (PSOCKADDR)&bindAddr, sizeof(bindAddr)) != 0)
 			{
 				port++;
-				if (port == Pointer(0x1860454).Read<uint32_t>()) // make sure port isn't the same as game port
-					port++;
 				bindAddr.sin_port = htons((u_short)port);
 				if (port > (Modules::ModuleServer::Instance().VarServerPort->ValueInt + 10))
 					return false; // tried 10 ports, lets give up


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Remove useless checks.

### Why should this pull request be merged?
The game uses UDP and the info server uses TCP so there is no problem with them being on the same port, which means the checks are useless.
### Have you tested this on your own and/or in a game with other people?
Yes.