### PR TITLE
Handled an exception thrown in TagInstance::GetInstancesInGroup.

### DIFF
--- a/ElDorito/Source/Blam/Tags/TagInstance.hpp
+++ b/ElDorito/Source/Blam/Tags/TagInstance.hpp
@@ -60,12 +60,18 @@ namespace Blam::Tags
 		// Gets all valid tag instances within the specified tag group
 		inline static std::vector<TagInstance> GetInstancesInGroup(const Tag groupTag)
 		{
+			typedef void *(*GetTagAddressPtr)(int groupTag, uint32_t index);
+			auto GetTagAddressImpl = reinterpret_cast<GetTagAddressPtr>(0x503370);
+
 			auto tagCount = *reinterpret_cast<uint32_t *>(0x22AB008);
 			std::vector<TagInstance> result;
 
 			for (auto i = 0; i < tagCount; i++)
 			{
 				auto instance = TagInstance(i);
+
+				if (GetTagAddressImpl(groupTag, instance.Index) == nullptr)
+					continue;
 
 				if (instance.GetDefinition<void>() == nullptr)
 					continue;


### PR DESCRIPTION
Previously the method would attempt to get the group tag of unloaded tags, which would cause the game to crash if not all tags in the group were loaded.

### Proposed changes in this pull request:

1. Check if a tag is loaded before trying to return it's instance.

### Why should this pull request be merged?
Fixes an unexpected crash.
### Have you tested this on your own and/or in a game with other people?
Tested alone multiple times.