### PR TITLE
Disabled HUD distortion in third person.

### DIFF
--- a/ElDorito/ElDorito.vcxproj
+++ b/ElDorito/ElDorito.vcxproj
@@ -193,6 +193,7 @@
     <ClInclude Include="Source\Blam\Tags\Game\TerritoriesVariant.hpp" />
     <ClInclude Include="Source\Blam\Tags\Game\TraitsProfile.hpp" />
     <ClInclude Include="Source\Blam\Tags\Game\VIPVariant.hpp" />
+    <ClInclude Include="Source\Blam\Tags\Globals\CacheFileGlobalTags.hpp" />
     <ClInclude Include="Source\Blam\Tags\Items\Item.hpp" />
     <ClInclude Include="Source\Blam\Tags\Items\Weapon.hpp" />
     <ClInclude Include="Source\Blam\Tags\Objects\Damage.hpp" />

--- a/ElDorito/ElDorito.vcxproj.filters
+++ b/ElDorito/ElDorito.vcxproj.filters
@@ -964,6 +964,9 @@
     </ClInclude>
     <ClInclude Include="Source\Forge\Geoemetry.hpp" />
     <ClInclude Include="Source\Forge\Magnets.hpp" />
+    <ClInclude Include="Source\Blam\Tags\Globals\CacheFileGlobalTags.hpp">
+      <Filter>Blam\Tags\Globals</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Source\ElDorito.rc" />
@@ -1052,6 +1055,9 @@
     </Filter>
     <Filter Include="Blam\Tags\Camera">
       <UniqueIdentifier>{f614a2e0-46cc-4cd5-9a17-8003f9df8d64}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Blam\Tags\Globals">
+      <UniqueIdentifier>{edd74372-6943-4855-a924-f620d4057ab0}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/ElDorito/Source/Blam/Tags/Globals/CacheFileGlobalTags.hpp
+++ b/ElDorito/Source/Blam/Tags/Globals/CacheFileGlobalTags.hpp
@@ -1,0 +1,24 @@
+#pragma once 
+#include "../Tags.hpp" 
+
+namespace Blam::Tags::Globals
+{
+	using Blam::Tags::TagBlock;
+	using Blam::Tags::TagGroup;
+	using Blam::Tags::TagReference;
+
+	struct CacheFileGlobalTags : TagGroup<'cfgt'>
+	{
+		struct GlobalsTags;
+
+		TagBlock<GlobalsTags> globalsTags;
+		int Unknown;
+
+		struct GlobalsTags
+		{
+			TagReference globalsTagReference;
+		};
+		TAG_STRUCT_SIZE_ASSERT(GlobalsTags, 0x10);
+	};
+	TAG_STRUCT_SIZE_ASSERT(CacheFileGlobalTags, 0x10);
+}

--- a/ElDorito/Source/Blam/Tags/UI/ChudGlobalsDefinition.hpp
+++ b/ElDorito/Source/Blam/Tags/UI/ChudGlobalsDefinition.hpp
@@ -123,7 +123,14 @@ namespace Blam::Tags::UI
 				uint8_t B;
 			};
 
-			int32_t Biped;
+			enum BipedValue : int32_t
+			{
+				Spartan,
+				Elite,
+				Monitor,
+			};
+
+			BipedValue Biped;
 			GlobalDynamicColor GlobalDynamicColors[37];
 			TagBlock<HudAttribute> HudAttributes;
 			TagBlock<HudSound> HudSounds;

--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -252,18 +252,7 @@ namespace Patches::Ui
 				if (hudGlobal.HudAttributes.Count < 1)
 					continue;
 
-				switch (hudGlobal.Biped)
-				{
-				case ChudGlobalsDefinition::HudGlobal::BipedValue::Spartan:
-					hudDistortionDirection[0] = hudGlobal.HudAttributes[0].WarpDirection;
-					break;
-				case ChudGlobalsDefinition::HudGlobal::BipedValue::Elite:
-					hudDistortionDirection[1] = hudGlobal.HudAttributes[0].WarpDirection;
-					break;
-				case ChudGlobalsDefinition::HudGlobal::BipedValue::Monitor:
-					hudDistortionDirection[2] = hudGlobal.HudAttributes[0].WarpDirection;
-					break;
-				}
+				hudDistortionDirection[hudGlobal.Biped] = hudGlobal.HudAttributes[0].WarpDirection;
 			}
 			firstHUDDistortionUpdate = false;
 			validHUDDistortionTags = true;
@@ -306,18 +295,7 @@ namespace Patches::Ui
 			if (chgd->HudGlobals[hudGlobalsIndex].HudAttributes.Count < 1)
 				continue;
 
-			switch (chgd->HudGlobals[hudGlobalsIndex].Biped)
-			{
-			case ChudGlobalsDefinition::HudGlobal::BipedValue::Spartan:
-				chgd->HudGlobals[hudGlobalsIndex].HudAttributes[0].WarpDirection = enabled ? hudDistortionDirection[0] : 0;
-				break;
-			case ChudGlobalsDefinition::HudGlobal::BipedValue::Elite:
-				chgd->HudGlobals[hudGlobalsIndex].HudAttributes[0].WarpDirection = enabled ? hudDistortionDirection[1] : 0;
-				break;
-			case ChudGlobalsDefinition::HudGlobal::BipedValue::Monitor:
-				chgd->HudGlobals[hudGlobalsIndex].HudAttributes[0].WarpDirection = enabled ? hudDistortionDirection[2] : 0;
-				break;
-			}
+			chgd->HudGlobals[hudGlobalsIndex].HudAttributes[0].WarpDirection = enabled ? hudDistortionDirection[chgd->HudGlobals[hudGlobalsIndex].Biped] : 0;
 		}
 		lastDistortionEnabledValue = enabled;
 	}

--- a/ElDorito/Source/Patches/Ui.hpp
+++ b/ElDorito/Source/Patches/Ui.hpp
@@ -35,4 +35,7 @@ namespace Patches::Ui
 	void SetVoiceChatIcon(VoiceChatIcon newIcon);
 	void UpdateVoiceChatHUD();
 	void ApplyAfterTagsLoaded();
+
+	void UpdateHUDDistortion();
+	void ToggleHUDDistortion(bool enabled);
 }


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Disabled HUD distortion when the player is not in first person.

2. Added a camera mode change hook, and a tag definition for CacheFileGlobalTags. Updated tag definition for ChudGlobals.

### Why should this pull request be merged?
The HUD behaved like this in Halo 3. Halo: Online introduced a lot of bugs with HUD globals, this is probably one of them. Without this patch, HUD distortion is applied in third person, which makes no sense, as in third person the player isn't looking through a visor.
### Have you tested this on your own and/or in a game with other people?
Tested alone, and with @Clef-0 and @luke231 .