### PR TITLE
Rework screenshot taking.

### DIFF
--- a/ElDorito/ElDorito.vcxproj
+++ b/ElDorito/ElDorito.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClCompile Include="Source\Blam\BitStream.cpp" />
     <ClCompile Include="Source\Blam\BlamData.cpp" />
+    <ClCompile Include="Source\Blam\BlamGraphics.cpp" />
     <ClCompile Include="Source\Blam\BlamInput.cpp" />
     <ClCompile Include="Source\Blam\BlamNetwork.cpp" />
     <ClCompile Include="Source\Blam\BlamObjects.cpp" />
@@ -145,6 +146,7 @@
     <ClInclude Include="Source\Blam\BitStream.hpp" />
     <ClInclude Include="Source\Blam\BlamData.hpp" />
     <ClInclude Include="Source\Blam\BlamEvents.hpp" />
+    <ClInclude Include="Source\Blam\BlamGraphics.hpp" />
     <ClInclude Include="Source\Blam\BlamInput.hpp" />
     <ClInclude Include="Source\Blam\BlamMemory.hpp" />
     <ClInclude Include="Source\Blam\BlamNetwork.hpp" />

--- a/ElDorito/ElDorito.vcxproj.filters
+++ b/ElDorito/ElDorito.vcxproj.filters
@@ -368,6 +368,9 @@
     </ClCompile>
     <ClCompile Include="Source\Forge\Magnets.cpp" />
     <ClCompile Include="Source\Patches\DirectXHook.cpp" />
+    <ClCompile Include="Source\Blam\BlamGraphics.cpp">
+      <Filter>Blam</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\CommandMap.hpp" />
@@ -967,6 +970,9 @@
       <Filter>Blam\Tags\Globals</Filter>
     </ClInclude>
     <ClInclude Include="Source\Patches\DirectXHook.hpp" />
+    <ClInclude Include="Source\Blam\BlamGraphics.hpp">
+      <Filter>Blam</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Source\ElDorito.rc" />

--- a/ElDorito/Source/Blam/BlamGraphics.cpp
+++ b/ElDorito/Source/Blam/BlamGraphics.cpp
@@ -1,0 +1,11 @@
+#include "BlamGraphics.hpp"
+
+namespace Blam::Graphics
+{
+	wchar_t* TakeScreenshot()
+	{
+		typedef wchar_t *(*TakeScreenshotPtr)();
+		auto TakeScreenshotImpl = reinterpret_cast<TakeScreenshotPtr>(0x60F420);
+		return TakeScreenshotImpl();
+	}
+}

--- a/ElDorito/Source/Blam/BlamGraphics.hpp
+++ b/ElDorito/Source/Blam/BlamGraphics.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace Blam::Graphics
+{
+	// Returns the location to which the screenshot will be saved to.
+	wchar_t* TakeScreenshot();
+}

--- a/ElDorito/Source/CommandMap.cpp
+++ b/ElDorito/Source/CommandMap.cpp
@@ -382,6 +382,7 @@ namespace Modules
 		int lineIdx = 0;
 		while (std::getline(stream, line))
 		{
+			line.erase(line.find_last_not_of("\r") + 1);
 			if (!this->ExecuteCommandWithStatus(line, isUserInput, &output))
 			{
 				ss << "Error at line " << lineIdx << std::endl;

--- a/ElDorito/Source/ElDorito.cpp
+++ b/ElDorito/Source/ElDorito.cpp
@@ -122,9 +122,9 @@ void ElDorito::Initialize()
 	Modules::CommandMap::Instance().ExecuteCommand("Execute autoexec.cfg"); // also execute autoexec, which is a user-made cfg guaranteed not to be overwritten by ElDew
 
 	// maybe use an unordered_map here
-	if (!Modules::ModuleInput::Instance().IsCommandBinded("game.takescreenshot"))
+	if (!Modules::ModuleInput::Instance().IsCommandBound("game.takescreenshot"))
 		Modules::CommandMap::Instance().ExecuteCommand("Bind PrintScreen Game.TakeScreenshot");
-	if (!Modules::ModuleInput::Instance().IsCommandBinded("voip.talk"))
+	if (!Modules::ModuleInput::Instance().IsCommandBound("voip.talk"))
 		Modules::CommandMap::Instance().ExecuteCommand("Bind CAPITAL +VoIP.Talk");
 
 	mapsFolder = "maps\\";

--- a/ElDorito/Source/ElDorito.cpp
+++ b/ElDorito/Source/ElDorito.cpp
@@ -23,6 +23,7 @@
 #include "Modules/ModuleGame.hpp"
 #include "Patch.hpp"
 #include "Modules/ModuleCamera.hpp"
+#include "Modules/ModuleInput.hpp"
 #include "Server/Voting.hpp"
 #include "ChatCommands/ChatCommandMap.hpp"
 #include "Patches/Weapon.hpp"
@@ -120,8 +121,11 @@ void ElDorito::Initialize()
 	}
 	Modules::CommandMap::Instance().ExecuteCommand("Execute autoexec.cfg"); // also execute autoexec, which is a user-made cfg guaranteed not to be overwritten by ElDew
 
-	//This should be removed when we can save binds
-	Modules::CommandMap::Instance().ExecuteCommand("Bind CAPITAL +VoIP.Talk");
+	// maybe use an unordered_map here
+	if (!Modules::ModuleInput::Instance().IsCommandBinded("game.takescreenshot"))
+		Modules::CommandMap::Instance().ExecuteCommand("Bind PrintScreen Game.TakeScreenshot");
+	if (!Modules::ModuleInput::Instance().IsCommandBinded("voip.talk"))
+		Modules::CommandMap::Instance().ExecuteCommand("Bind CAPITAL +VoIP.Talk");
 
 	mapsFolder = "maps\\";
 

--- a/ElDorito/Source/Modules/ModuleGame.cpp
+++ b/ElDorito/Source/Modules/ModuleGame.cpp
@@ -8,6 +8,7 @@
 #include "../Patches/Logging.hpp"
 #include "../Blam/BlamTypes.hpp"
 #include "../Blam/BlamNetwork.hpp"
+#include "../Blam/BlamGraphics.hpp"
 #include "../Blam/Tags/Game/GameEngineSettings.hpp"
 #include "../Patches/Core.hpp"
 #include "../Patches/Forge.hpp"
@@ -22,6 +23,7 @@
 #include "../ThirdParty/rapidjson/stringbuffer.h"
 #include "../ThirdParty/rapidjson/writer.h"
 #include <unordered_map>
+#include <codecvt>
 
 namespace
 {
@@ -857,6 +859,26 @@ namespace
 		return true;
 	}
 
+	bool CommandGameTakeScreenshot(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{	
+		wchar_t *path = Blam::Graphics::TakeScreenshot();
+		wchar_t full_path[400];
+		_wfullpath(full_path, path, 400);
+		std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_to_string;
+		std::string screenshot_path = wstring_to_string.to_bytes(full_path);
+
+		rapidjson::StringBuffer jsonBuffer;
+		rapidjson::Writer<rapidjson::StringBuffer> jsonWriter(jsonBuffer);
+		jsonWriter.StartObject();
+		jsonWriter.Key("filepath");
+		jsonWriter.String(screenshot_path.c_str());
+		jsonWriter.EndObject();
+		Web::Ui::ScreenLayer::Show("screenshot_notice", jsonBuffer.GetString());
+
+		returnInfo = "Screenshot saved to: " + screenshot_path;
+		return true;
+	}
+
 	bool VariableLanguageUpdated(const std::vector<std::string>& arguments, std::string& returnInfo)
 	{
 		if (arguments.size() < 1)
@@ -941,6 +963,8 @@ namespace Modules
 
 		AddCommand("PlaySound", "play_sound", "Plays a sound effect", CommandFlags(eCommandFlagsHidden | eCommandFlagsOmitValueInList), CommandPlaySound);
 
+		AddCommand("TakeScreenshot", "take_screenshot", "Take a screenshot", eCommandFlagsNone, CommandGameTakeScreenshot);
+
 		VarMenuURL = AddVariableString("MenuURL", "menu_url", "url(string) The URL of the page you want to load inside the menu", eCommandFlagsArchived, "http://scooterpsu.github.io/");
 
 		VarLanguage = AddVariableString("Language", "language", "The language to use", eCommandFlagsArchived, "english", VariableLanguageUpdated);
@@ -982,6 +1006,8 @@ namespace Modules
 		VarHideH3UI = AddVariableInt("HideH3UI", "hide_h3ui", "Hide the H3 UI", eCommandFlagsHidden, 0);
 		VarHideH3UI->ValueIntMin = 0;
 		VarHideH3UI->ValueIntMax = 1;
+
+		VarScreenshotsFolder = AddVariableString("ScreenshotsFolder", "screenshots_folder", "The location where the game will save screenshots", eCommandFlagsArchived, "%userprofile%\\Pictures\\Screenshots\\blam");
 
 		// Level load patch
 		Patch::NopFill(Pointer::Base(0x2D26DF), 5);

--- a/ElDorito/Source/Modules/ModuleGame.hpp
+++ b/ElDorito/Source/Modules/ModuleGame.hpp
@@ -21,6 +21,7 @@ namespace Modules
 		Command* VarIconSet;
 		Command* VarFixHudGlobals;
 		Command* VarHideH3UI;
+		Command* VarScreenshotsFolder;
 
 		int DebugFlags;
 

--- a/ElDorito/Source/Modules/ModuleInput.cpp
+++ b/ElDorito/Source/Modules/ModuleInput.cpp
@@ -785,16 +785,16 @@ namespace Modules
 		}
 		return result;
 	}
-	bool ModuleInput::IsCommandBinded(std::string command)
+	bool ModuleInput::IsCommandBound(std::string command)
 	{
 		for (int i = 0; i < eKeyCode_Count; i++)
 		{
 			const auto binding = &commandBindings[i];
 			if (binding->command.size() == 0)
 				continue; // Key is not bound
-			std::string binded_command = binding->command[0];
-			std::transform(binded_command.begin(), binded_command.end(), binded_command.begin(), ::tolower);
-			if (command.compare(binded_command) == 0)
+			std::string bound_command = binding->command[0];
+			std::transform(bound_command.begin(), bound_command.end(), bound_command.begin(), ::tolower);
+			if (command.compare(bound_command) == 0)
 				return true;
 		}
 		return false;

--- a/ElDorito/Source/Modules/ModuleInput.cpp
+++ b/ElDorito/Source/Modules/ModuleInput.cpp
@@ -1,5 +1,6 @@
 #include "ModuleInput.hpp"
 #include <sstream>
+#include <algorithm>
 #include "../ElDorito.hpp"
 #include "../Patches/Input.hpp"
 #include "../Console.hpp"
@@ -576,6 +577,8 @@ namespace
 			returnInfo = "Not enough arguments";
 			return false;
 		}
+		std::string search_for = Arguments[0];
+		std::transform(search_for.begin(), search_for.end(), search_for.begin(), ::tolower);
 		rapidjson::StringBuffer buffer;
 		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
@@ -584,7 +587,9 @@ namespace
 		{
 			for (int k = 0; k < commandBindings[i].command.size(); k++)
 			{
-				if (commandBindings[i].command[k].compare(Arguments[0]) == 0)
+				std::string command_part = commandBindings[i].command[k];
+				std::transform(command_part.begin(), command_part.end(), command_part.begin(), ::tolower);
+				if (command_part.compare(search_for) == 0)
 				{
 					std::string key;
 					keyCodes.FindName((Blam::Input::KeyCode)i, &key);
@@ -779,6 +784,20 @@ namespace Modules
 			result += line + "\n";
 		}
 		return result;
+	}
+	bool ModuleInput::IsCommandBinded(std::string command)
+	{
+		for (int i = 0; i < eKeyCode_Count; i++)
+		{
+			const auto binding = &commandBindings[i];
+			if (binding->command.size() == 0)
+				continue; // Key is not bound
+			std::string binded_command = binding->command[0];
+			std::transform(binded_command.begin(), binded_command.end(), binded_command.begin(), ::tolower);
+			if (command.compare(binded_command) == 0)
+				return true;
+		}
+		return false;
 	}
 }
 

--- a/ElDorito/Source/Modules/ModuleInput.hpp
+++ b/ElDorito/Source/Modules/ModuleInput.hpp
@@ -32,6 +32,6 @@ namespace Modules
 		static Blam::Input::BindingsTable *GetBindings();
 		static void UpdateBindings();
 		std::string ExportBindings() const;
-		bool IsCommandBinded(std::string command);
+		bool IsCommandBound(std::string command);
 	};
 }

--- a/ElDorito/Source/Modules/ModuleInput.hpp
+++ b/ElDorito/Source/Modules/ModuleInput.hpp
@@ -32,5 +32,6 @@ namespace Modules
 		static Blam::Input::BindingsTable *GetBindings();
 		static void UpdateBindings();
 		std::string ExportBindings() const;
+		bool IsCommandBinded(std::string command);
 	};
 }

--- a/ElDorito/Source/Patches/Input.cpp
+++ b/ElDorito/Source/Patches/Input.cpp
@@ -32,6 +32,7 @@ namespace
 	char GetControllerStateHook(int dwUserIndex, int a2, void *a3);
 	void SetControllerVibrationHook(int controllerIndex, uint16_t leftMotorSpeed, uint16_t rightMotorSpeed);
 	void LocalPlayerInputHook(int localPlayerIndex, uint32_t playerIndex, int a3, int a4, int a5, uint8_t* state);
+	void null_stub() {};
 
 	// Block/unblock input without acquiring or de-acquiring the mouse
 	void QuickBlockInput();
@@ -67,6 +68,7 @@ namespace Patches::Input
 		Hook(0x20C4F6, GetKeyboardActionTypeHook).Apply();
 		Hook(0x1128FB, GetControllerStateHook, HookFlags::IsCall).Apply();
 		Hook(0x1124F0, SetControllerVibrationHook).Apply();
+		Hook(0x105C58, null_stub, HookFlags::IsCall).Apply(); // remove the hardcoded binding of screenshot to printscreen
 		Patch::NopFill(Pointer::Base(0x6A225B), 2); // Prevent the game from forcing certain binds on load
 		Patch(0x6940E7, { 0x90, 0xE9 }).Apply(); // Disable custom UI input code
 		Hook(0x695012, UpdateUiControllerInputHook, HookFlags::IsCall).Apply();

--- a/dist/mods/ui/web/screens/screens.json
+++ b/dist/mods/ui/web/screens/screens.json
@@ -102,6 +102,12 @@
 			"url": "dew://screens/controllerSensitivity/",
 			"captureInput": true,
 			"zIndex": 1
+		},
+		{
+			"id": "screenshot_notice",
+			"url": "dew://screens/screenshot_notice/",
+			"captureInput": false,
+			"zIndex": 90
 		}
 	]
 }

--- a/dist/mods/ui/web/screens/screenshot_notice/index.html
+++ b/dist/mods/ui/web/screens/screenshot_notice/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!-- HTML and CSS designed by soular00t-->
+<html>
+    <head>
+          <title>Screemshot taken</title>
+          <script src="dew://lib/jquery-2.2.1.min.js"></script>
+		  <script src="dew://lib/dew.js"></script>
+		  <script src="screenshot_notice.js"></script>
+          <style>
+            @font-face{ font-family:"Conduit ITC"; src:url(dew://lib/Conduit-ITC.woff); }
+            @keyframes slideInFromRight {
+              0% { transform: translateX(100%); }
+              100% { transform: translateX(0);  }
+            }
+            * {
+                margin: 0;
+                padding: 0;
+                font-family: "Conduit ITC";
+                -webkit-user-select: none;
+                user-select: none;
+                -webkit-font-smoothing: antialiased;
+            }
+            html {
+                color: #FFF;
+                zoom: 0.85;
+            }
+            html:before {
+                content: "";
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                filter: blur(2px);
+            }
+            </style>
+    </head>
+    <body>
+        <div style="padding:30px;
+        border-radius:20px;
+        box-shadow:0px 0px 45px rgba(0,0,0,0.7);
+        background:linear-gradient(rgba(25,41,77, 1.0),rgba(21, 30, 39, 0.9));
+        position:absolute;
+        bottom:10px;
+        left:10px;">Screenshot saved to:<br /><span id='savedto'></span></div>
+    </body>
+</html>

--- a/dist/mods/ui/web/screens/screenshot_notice/screenshot_notice.js
+++ b/dist/mods/ui/web/screens/screenshot_notice/screenshot_notice.js
@@ -1,0 +1,17 @@
+function fadeOut() {
+	$(document.body).fadeOut( "fast", function() {
+		dew.hide();
+	});
+}
+
+var hide_timer
+
+dew.on("show", function (event) {
+	$(document.body).stop()
+	clearTimeout(hide_timer)
+
+    $(document.body).show();
+	$('#savedto').html(document.createTextNode(event.data.filepath));
+
+	hide_timer = setTimeout(fadeOut, 2000);
+});


### PR DESCRIPTION
### Proposed changes in this pull request:
- Removes hardcoded binding of screenshot to printscreen
- Add new `Game.TakeScreenshot` command
- Add new variable `Game.ScreenshotsFolder`
- Allow setting the bindings for `Game.TakeScreenshot` and the value of `Game.ScreenshotsFolder` in the settings menu.
- Add popup that tells the user a screenshot was taken and where it was saved to

The HTML for the popup was designed by @soular00t

### Why should this pull request be merged?
It allows setting the location to which screenshots are saved. It lets anyone that already has another program like sharex binded to printscreen rebind it to another button. It also adds a screenshot taken dialog which makes sure users know they can take screenshots and tells them where the game saves screenshots to.
### Have you tested this on your own and/or in a game with other people?
yes