### PR TITLE
Fix the screenshots folder not being auto created if `Game.ScreenshotsFolder` is a relative and not absolute path.

### DIFF
--- a/ElDorito/Source/Patches/Core.cpp
+++ b/ElDorito/Source/Patches/Core.cpp
@@ -396,6 +396,6 @@ namespace
 			static auto GetScreenshotsFolder = (int(__cdecl*)(wchar_t *path))(0x724BB0);
 			return GetScreenshotsFolder(path);
 		}
-		return SHCreateDirectoryExW(NULL, path, NULL);
+		return CreateDirectoryW(path, NULL);
 	}
 }


### PR DESCRIPTION
I made the mistake of using the same API function the game uses without checking if there is a better option.