### PR TITLE
HUD State Fixes

### DIFF
--- a/ElDorito/Source/Blam/Tags/UI/ChudDefinition.hpp
+++ b/ElDorito/Source/Blam/Tags/UI/ChudDefinition.hpp
@@ -82,9 +82,9 @@ namespace Blam::Tags::UI
 		enum class StateDataEngineFlags2 : uint16_t
 		{
 			None = 0,
-			Bit0 = 1 << 0,
-			Bit1 = 1 << 1,
-			Bit2 = 1 << 2,
+			Biped1 = 1 << 0,
+			Biped2 = 1 << 1,
+			Biped3 = 1 << 2,
 			Bit3 = 1 << 3,
 			Bit4 = 1 << 4,
 			Bit5 = 1 << 5,

--- a/ElDorito/Source/Modules/ModuleVoIP.cpp
+++ b/ElDorito/Source/Modules/ModuleVoIP.cpp
@@ -39,8 +39,6 @@ namespace
 
 		Web::Ui::ScreenLayer::Notify("voip-settings", buffer.GetString(), true);
 
-		Patches::Ui::UpdateVoiceChatHUD(false);
-
 		returnInfo = "";
 		return true;
 	}
@@ -48,11 +46,7 @@ namespace
 	void RendererStarted(const char* map)
 	{
 		if (std::string(map).find("mainmenu") == std::string::npos)
-		{
 			isMainMenu = false;
-
-			Patches::Ui::UpdateVoiceChatHUD(false);
-		}
 		else
 			isMainMenu = true;
 		ready = true;
@@ -77,7 +71,7 @@ namespace
 				isChatting = false;
 				if (!isMainMenu)
 				{
-					Patches::Ui::UpdateVoiceChatHUD(false);
+					Patches::Ui::TogglePTTSound(false);
 				}
 				Web::Ui::ScreenLayer::Notify("voip-ptt", "{\"talk\":0}", true);
 			}
@@ -86,7 +80,7 @@ namespace
 				isChatting = true;
 				if (!isMainMenu)
 				{
-					Patches::Ui::UpdateVoiceChatHUD(false);
+					Patches::Ui::TogglePTTSound(true);
 				}
 
 				Web::Ui::ScreenLayer::Notify("voip-ptt", "{\"talk\":1}", true);

--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -94,7 +94,7 @@ namespace Patches::Ui
 		tagsInitiallyLoaded = true;
 
 		UpdateSpeakingPlayerWidget(true);
-		UpdateHUDDistortion(true);
+		UpdateHUDDistortion();
 	}
 
 	void ApplyAll()
@@ -543,14 +543,8 @@ namespace Patches::Ui
 		}
 	}
 
-	void UpdateHUDDistortion(bool mapLoaded)
+	void UpdateHUDDistortion()
 	{
-		if ((IsMapLoading() || IsMainMenu()) && !mapLoaded)
-			return;
-
-		if (!tagsInitiallyLoaded)
-			return;
-
 		if (!validHUDDistortionTags)
 			return;
 
@@ -572,10 +566,7 @@ namespace Patches::Ui
 	bool lastDistortionEnabledValue;
 	void ToggleHUDDistortion(bool enabled)
 	{
-		if (IsMapLoading() || IsMainMenu())
-			return;
-
-		if (!tagsInitiallyLoaded)
+		if (!validHUDDistortionTags)
 			return;
 
 		if (enabled == lastDistortionEnabledValue)
@@ -1275,7 +1266,7 @@ namespace
 		}
 	}
 
-	//Called if equipment held (flags 0x100)
+	//Called if equipment held
 	__declspec(naked) void StateDataFlags31Hook()
 	{
 		__asm 

--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -196,7 +196,7 @@ namespace Patches::Ui
 		Hook(0x686E7B, StateDataFlags3Hook).Apply();
 		Hook(0x687094, StateDataFlags5Hook).Apply();
 		Hook(0x687BF0, StateDataFlags21Hook).Apply();
-		Hook(0x685A6B, StateDataFlags31Hook).Apply();
+		Hook(0x685A5A, StateDataFlags31Hook).Apply();
 	}
 
 	const auto UI_Alloc = reinterpret_cast<void *(__cdecl *)(int32_t)>(0xAB4ED0);

--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -52,8 +52,14 @@ namespace
 	void __fastcall c_main_menu_screen_widget_item_select_hook(void* thisptr, void* unused, int a2, int a3, void* a4, void* a5);
 	void __fastcall c_ui_view_draw_hook(void* thisptr, void* unused);
 	void CameraModeChangedHook();
-	void StateDataBipedFlagsHook();
-	int GetActiveChudState2FlagsValue();
+	void StateDataFlags2Hook();
+	void StateDataFlags3Hook();
+	void StateDataFlags5Hook();
+	void StateDataFlags21Hook();
+	int GetBrokenChudStateFlags2Values();
+	int GetBrokenChudStateFlags3Values();
+	int GetBrokenChudStateFlags5Values();
+	int GetBrokenChudStateFlags21Values();
 
 	std::vector<CreateWindowCallback> createWindowCallbacks;
 
@@ -85,7 +91,6 @@ namespace Patches::Ui
 
 		tagsInitiallyLoaded = true;
 
-		UpdateVoiceChatHUD(true);
 		UpdateSpeakingPlayerWidget(true);
 		UpdateHUDDistortion(true);
 	}
@@ -185,7 +190,10 @@ namespace Patches::Ui
 		
 		Hook(0x193370, CameraModeChangedHook, HookFlags::IsCall).Apply();
 
-		Hook(0x686FA4, StateDataBipedFlagsHook).Apply();
+		Hook(0x686FA4, StateDataFlags2Hook).Apply();
+		Hook(0x686E7B, StateDataFlags3Hook).Apply();
+		Hook(0x687094, StateDataFlags5Hook).Apply();
+		Hook(0x687BF0, StateDataFlags21Hook).Apply();
 	}
 
 	const auto UI_Alloc = reinterpret_cast<void *(__cdecl *)(int32_t)>(0xAB4ED0);
@@ -216,7 +224,6 @@ namespace Patches::Ui
 	{
 		FindUiTagIndices(); //Call me first.
 		FindVoiceChatSpeakingPlayerTagData();
-		FindVoiceChatIconsTagData();
 		FindHUDDistortionTagData();
 		FindHUDResolutionTagData();
 	}
@@ -331,7 +338,6 @@ namespace Patches::Ui
 	
 	bool speakingPlayerStringFound = false;
 	uint32_t speakingPlayerOffset; //The offset of speaker_name in memory.
-	uint32_t speakingPlayerIndex = 0; //Hud Widget Containing Speaker.
 	void FindVoiceChatSpeakingPlayerTagData()
 	{
 		using Blam::Tags::TagInstance;
@@ -355,101 +361,7 @@ namespace Patches::Ui
 		if (speakingPlayerOffset != NULL)
 			speakingPlayerStringFound = true;
 		else
-		{
 			speakingPlayerStringFound = false;
-			UpdateVoiceChatHUD(false);
-		}
-	}
-
-	uint16_t teamBroadcastIndicatorIndex = 0; //Hud Widget containing Icons.
-	uint16_t broadcastAvailableIndex = 0; //Can Talk Icon
-	uint16_t broadcastIndex = 0; //Talking Icon.
-	uint16_t broadcastPTTIndex = 0; //Push To Talk Icon
-	uint16_t broadcastNoIndex = 0; //Can't Talk Icon
-	uint16_t spartanMotionTrackerIndex = 0; //motion_tracker hud widget.
-	uint16_t spartanVoiceBroadcast1Index = 0; //Speaking radar icon 1.
-	uint16_t spartanVoiceBroadcast2Index = 0; //Speaking radar icon 2.											
-	//Support for the elite HUD, just in case any mods need it.
-	uint16_t eliteMotionTrackerIndex = 0;
-	uint16_t eliteVoiceBroadcast1Index = 0; //Speaking radar icon 1.
-	uint16_t eliteVoiceBroadcast2Index = 0; //Speaking radar icon 2.
-	bool voiceChatIconValidTags = false;
-	void FindVoiceChatIconsTagData()
-	{
-		using Blam::Tags::TagInstance;
-		using Blam::Tags::UI::ChudDefinition;
-
-		if (!TagInstance::IsLoaded('chdt', scoreboardChdtIndex))
-			return;
-		else if (!TagInstance::IsLoaded('chdt', spartanChdtIndex))
-			return;
-
-		auto *scoreboardChud = Blam::Tags::TagInstance(scoreboardChdtIndex).GetDefinition<Blam::Tags::UI::ChudDefinition>();
-		auto *spartanChud = Blam::Tags::TagInstance(spartanChdtIndex).GetDefinition<Blam::Tags::UI::ChudDefinition>();
-
-		//If it's the first time updating the HUD, find the tagblock indexes.
-		//Find widgets in spartan.
-		for (int hudWidgetBlock = 0; hudWidgetBlock < spartanChud->HudWidgets.Count; hudWidgetBlock++)
-		{
-			if (spartanChud->HudWidgets[hudWidgetBlock].NameStringID == 0x2A76) //motion_tracker
-			{
-				spartanMotionTrackerIndex = hudWidgetBlock;
-
-				for (int bitmapWidgetBlock = 0; bitmapWidgetBlock < spartanChud->HudWidgets[hudWidgetBlock].BitmapWidgets.Count; bitmapWidgetBlock++)
-				{
-					if (spartanChud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x2A77) //voice_broadcast1
-						spartanVoiceBroadcast1Index = bitmapWidgetBlock;
-					else if (spartanChud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x2A78) //voice_broadcast2
-						spartanVoiceBroadcast2Index = bitmapWidgetBlock;
-
-					if (spartanVoiceBroadcast1Index != NULL && spartanVoiceBroadcast2Index != NULL)
-						break;
-				}
-			}
-			if (spartanMotionTrackerIndex != NULL)
-				break;
-		}
-
-		//Find widgets in scoreboard.
-		for (int hudWidgetBlock = 0; hudWidgetBlock < scoreboardChud->HudWidgets.Count; hudWidgetBlock++)
-		{
-			if (scoreboardChud->HudWidgets[hudWidgetBlock].NameStringID == 0x45C2) // team_broadcast_indicator
-			{
-				teamBroadcastIndicatorIndex = hudWidgetBlock;
-
-				for (int bitmapWidgetBlock = 0; bitmapWidgetBlock < scoreboardChud->HudWidgets[hudWidgetBlock].BitmapWidgets.Count; bitmapWidgetBlock++)
-				{
-					if (scoreboardChud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C3) // broadcast
-						broadcastIndex = bitmapWidgetBlock;
-					else if (scoreboardChud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C4) // broadcast_available
-						broadcastAvailableIndex = bitmapWidgetBlock;
-					else if (scoreboardChud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C5) // broadcast_ptt_sybmol
-						broadcastPTTIndex = bitmapWidgetBlock;
-					else if (scoreboardChud->HudWidgets[hudWidgetBlock].BitmapWidgets[bitmapWidgetBlock].NameStringID == 0x45C6) // broadcast_no
-						broadcastNoIndex = bitmapWidgetBlock;
-
-					//if everything is found, break early.
-					if (((broadcastIndex != NULL) && (broadcastAvailableIndex != NULL)) && ((broadcastPTTIndex != NULL) && (broadcastNoIndex != NULL)))
-						break;
-				}
-			}
-			if (scoreboardChud->HudWidgets[hudWidgetBlock].NameStringID == 0x45BF) // speaker_name
-			{
-				speakingPlayerIndex = hudWidgetBlock;
-			}
-			if ((teamBroadcastIndicatorIndex != NULL) && (speakingPlayerIndex != NULL))
-				break;
-		}
-
-		//Check the availability of statedata, positiondata.
-		if (scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastIndex].StateData.Count > 0 &&
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].StateData.Count > 0 &&
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastNoIndex].StateData.Count > 0 &&
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastPTTIndex].StateData.Count > 0 &&
-			scoreboardChud->HudWidgets[speakingPlayerIndex].StateData.Count > 0 &&
-			spartanChud->HudWidgets[spartanMotionTrackerIndex].BitmapWidgets[spartanVoiceBroadcast1Index].StateData.Count > 0 &&
-			spartanChud->HudWidgets[spartanMotionTrackerIndex].BitmapWidgets[spartanVoiceBroadcast2Index].StateData.Count > 0)
-			voiceChatIconValidTags = true;
 	}
 
 	bool firstHUDDistortionUpdate = true;
@@ -584,20 +496,12 @@ namespace Patches::Ui
 
 		std::string newName;
 
-		if (speakingPlayers.size() < 1)
-		{
-			UpdateVoiceChatHUD(false);
-			return;
-		}
+		if (speakingPlayers.size() < 1) return;
 		else if (speakingPlayers[speakingPlayers.size() - 1].length() < 15) // player names are limited to 15 anyway.
 		{
 			newName = speakingPlayers[speakingPlayers.size() - 1];
 		}
-		else
-		{
-			UpdateVoiceChatHUD(false);
-			return;
-		}
+		else return;
 
 		std::string newHudMessagesStrings;
 		newHudMessagesStrings.reserve(30);
@@ -634,22 +538,6 @@ namespace Patches::Ui
 
 			unic->Data.Elements[dataIndex + speakingPlayerOffset] = static_cast<unsigned char>(tmpValue);
 		}
-
-		if (speakingPlayerIndex != NULL)
-		{
-			if (!TagInstance::IsLoaded('chdt', scoreboardChdtIndex))
-				return;
-
-			auto *chud = Blam::Tags::TagInstance(scoreboardChdtIndex).GetDefinition<Blam::Tags::UI::ChudDefinition>();
-
-			if (chud->HudWidgets.Count < 1 || chud->HudWidgets[speakingPlayerIndex].TextWidgets.Count < 1)
-				return;
-
-			//Make sure that the speaking player HUD widget has the correct string.
-			chud->HudWidgets[speakingPlayerIndex].TextWidgets[0].TextStringID = speakingPlayerStringID;
-		}
-
-		UpdateVoiceChatHUD(false);
 	}
 
 	void UpdateHUDDistortion(bool mapLoaded)
@@ -707,115 +595,6 @@ namespace Patches::Ui
 			chgd->HudGlobals[hudGlobalsIndex].HudAttributes[0].WarpDirection = enabled ? hudDistortionDirection[chgd->HudGlobals[hudGlobalsIndex].Biped] : 0;
 		}
 		lastDistortionEnabledValue = enabled;
-	}
-
-	void UpdateVoiceChatHUD(bool mapLoaded)
-	{
-		if ((IsMapLoading() || IsMainMenu()) && !mapLoaded)
-			return;
-
-		if (!tagsInitiallyLoaded)
-			return;
-
-		VoiceChatIcon newIcon;
-
-		Modules::ModuleVoIP &voipModule = Modules::ModuleVoIP::Instance();
-
-		if (voipModule.VarVoipEnabled->ValueInt == 0)
-		{
-			newIcon = VoiceChatIcon::None;
-		}
-		else if (voipModule.voipConnected)
-		{
-			if (voipModule.VarPTTEnabled->ValueInt == 0)
-			{
-				if (voipModule.voiceDetected)
-					newIcon = VoiceChatIcon::Speaking;
-				else
-					newIcon = VoiceChatIcon::Available;
-			}
-			else
-			{
-				if (Blam::Input::GetActionState(Blam::Input::eGameActionVoiceChat)->Ticks > 0 || voipModule.voiceDetected)
-				{
-					newIcon = VoiceChatIcon::Speaking;
-					TogglePTTSound(true);
-				}
-				else
-				{
-					newIcon = VoiceChatIcon::PushToTalk;
-					TogglePTTSound(false);
-				}
-			}
-		}
-		else
-		{
-			newIcon = VoiceChatIcon::Unavailable;
-		}
-
-		if (!tagsInitiallyLoaded)
-			return;
-
-		using Blam::Tags::TagInstance;
-		using Blam::Tags::UI::ChudDefinition;
-
-		//If there's no data to toggle (due to modded tags), do nothing.
-		if (!voiceChatIconValidTags)
-			return;
-
-		if (!TagInstance::IsLoaded('chdt', scoreboardChdtIndex))
-			return;
-		else if (!TagInstance::IsLoaded('chdt', spartanChdtIndex))
-			return;
-
-		auto *scoreboardChud = Blam::Tags::TagInstance(scoreboardChdtIndex).GetDefinition<Blam::Tags::UI::ChudDefinition>();
-		auto *spartanChud = Blam::Tags::TagInstance(spartanChdtIndex).GetDefinition<Blam::Tags::UI::ChudDefinition>();
-
-		if (scoreboardChud->HudWidgets.Count < teamBroadcastIndicatorIndex + 1)
-			return;
-		else if (scoreboardChud->HudWidgets.Count < speakingPlayerIndex + 1)
-			return;
-		else if (spartanChud->HudWidgets.Count < spartanMotionTrackerIndex + 1)
-			return;
-
-		//Hide all Icons.
-		//Bit 7 is the broken "Tap to Talk" state used in halo 3.
-		//Disabling the icon using a broken state triggers the close animation. Then removing this state triggers the open animation.
-		scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastIndex].StateData[0].EngineFlags3 = ChudDefinition::StateDataEngineFlags3::Bit7;
-		scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].StateData[0].EngineFlags3 = ChudDefinition::StateDataEngineFlags3::Bit7;
-		scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastNoIndex].StateData[0].EngineFlags3 = ChudDefinition::StateDataEngineFlags3::Bit7;
-		scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastPTTIndex].StateData[0].EngineFlags3 = ChudDefinition::StateDataEngineFlags3::Bit7;
-
-		scoreboardChud->HudWidgets[speakingPlayerIndex].StateData[0].ScoreboardFlags1 = ChudDefinition::StateDataScoreboardFlags1::Bit3;
-
-		spartanChud->HudWidgets[spartanMotionTrackerIndex].BitmapWidgets[spartanVoiceBroadcast1Index].StateData[0].UnknownFlags13 = ChudDefinition::StateDataUnknownFlags::Bit10;
-		spartanChud->HudWidgets[spartanMotionTrackerIndex].BitmapWidgets[spartanVoiceBroadcast2Index].StateData[0].UnknownFlags13 = ChudDefinition::StateDataUnknownFlags::Bit10;
-
-		//Show the correct Icon.
-		//To remove hardcoded scale values, we could store these default scales earlier by reading them on first update. I'm gonna leave them for now.
-		switch (newIcon)
-		{
-		case VoiceChatIcon::Speaking:
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastIndex].StateData[0].EngineFlags3 = (ChudDefinition::StateDataEngineFlags3)0;
-			spartanChud->HudWidgets[spartanMotionTrackerIndex].BitmapWidgets[spartanVoiceBroadcast1Index].StateData[0].UnknownFlags13 = (ChudDefinition::StateDataUnknownFlags)0;
-			spartanChud->HudWidgets[spartanMotionTrackerIndex].BitmapWidgets[spartanVoiceBroadcast2Index].StateData[0].UnknownFlags13 = (ChudDefinition::StateDataUnknownFlags)0;
-			break;
-		case VoiceChatIcon::Available:
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].StateData[0].EngineFlags3 = (ChudDefinition::StateDataEngineFlags3)0;
-			break;
-		case VoiceChatIcon::Unavailable:
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastNoIndex].StateData[0].EngineFlags3 = (ChudDefinition::StateDataEngineFlags3)0;
-			break;
-		case VoiceChatIcon::PushToTalk:
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastPTTIndex].StateData[0].EngineFlags3 = (ChudDefinition::StateDataEngineFlags3)0;
-			scoreboardChud->HudWidgets[teamBroadcastIndicatorIndex].BitmapWidgets[broadcastAvailableIndex].StateData[0].EngineFlags3 = (ChudDefinition::StateDataEngineFlags3)0;
-			break;
-		case VoiceChatIcon::None: //Not sure if this is even needed.
-			break;
-		}
-
-		if (speakingPlayerStringFound && speakingPlayers.size() > 0 && voipModule.VarSpeakingPlayerOnHUD->ValueInt == 1)
-			scoreboardChud->HudWidgets[speakingPlayerIndex].StateData[0].ScoreboardFlags1 = (ChudDefinition::StateDataScoreboardFlags1)0;
 	}
 	
 	void ApplyMapNameFixes()
@@ -1448,21 +1227,55 @@ namespace
 		}
 	}
 
-	__declspec(naked) void StateDataBipedFlagsHook()
+	__declspec(naked) void StateDataFlags2Hook()
 	{
 		__asm
 		{
-			call GetActiveChudState2FlagsValue
+			call GetBrokenChudStateFlags2Values
 			or word ptr[edi + 57Ah], ax
 			mov eax, 0xA86FC8
 			jmp eax
 		}
 	}
 
-	int GetActiveChudState2FlagsValue()
+	__declspec(naked) void StateDataFlags3Hook()
+	{
+		__asm
+		{
+			call GetBrokenChudStateFlags3Values
+			or word ptr[edi + 57Ch], ax
+			mov eax, 0xA86EEF
+			jmp eax
+		}
+	}
+
+	__declspec(naked) void StateDataFlags5Hook()
+	{
+		__asm
+		{
+			call GetBrokenChudStateFlags5Values
+			or word ptr[edi + 580h], ax
+			mov eax, 0xA870A6
+			jmp eax
+		}
+	}
+
+	__declspec(naked) void StateDataFlags21Hook()
+	{
+		__asm
+		{
+			call GetBrokenChudStateFlags21Values
+			or word ptr[edi + 5A0h], ax
+			cmp byte ptr[edi + 0x00062C], 00 //perform original instruction
+			mov eax, 0xA87BF7
+			jmp eax
+		}
+	}
+
+	//All values in this bitfield are broken.
+	int GetBrokenChudStateFlags2Values()
 	{
 		using Blam::Players::PlayerDatum;
-		using Blam::Tags::UI::ChudDefinition;
 
 		auto GetPlayerIndexFromPlayerDatum = (int(*)(PlayerDatum))(0x589C60);
 		auto sub_53A6F0 = (void*(*)(uint32_t))(0x53A6F0);
@@ -1480,5 +1293,79 @@ namespace
 		default:
 			return 1;
 		}
+	}
+
+	//All voice values in this bitfield are broken.
+	int GetBrokenChudStateFlags3Values()
+	{
+		int flags = 0;
+
+		Modules::ModuleVoIP &voipModule = Modules::ModuleVoIP::Instance();
+
+		if (!voipModule.VarVoipEnabled->ValueInt == 0)
+		{
+			if (voipModule.voipConnected)
+			{
+				if (voipModule.VarPTTEnabled->ValueInt == 0)
+				{
+					if (voipModule.voiceDetected)
+						flags |= 0x400; //talking
+					else
+						flags |= 0x200; //not_talking
+				}
+				else
+				{
+					if (Blam::Input::GetActionState(Blam::Input::eGameActionVoiceChat)->Ticks > 0)
+						flags |= 0x400; //talking
+					else
+					{
+						flags |= 0x80; //tap_to_talk
+						flags |= 0x200; //not_talking
+					}
+				}
+			}
+			else
+				flags |= 0x40; //taling_disabled
+		}
+
+		return flags;
+	}
+
+	//All voice values in this bitfield are broken.
+	int GetBrokenChudStateFlags5Values()
+	{
+		int flags = 0;
+
+		if (speakingPlayers.size() > 0)
+			flags |= 8; //SomeoneIsTalking
+
+		return flags;
+	}
+
+	//All voice values in this bitfield are broken.
+	int GetBrokenChudStateFlags21Values()
+	{
+		int flags = 0;
+
+		Modules::ModuleVoIP &voipModule = Modules::ModuleVoIP::Instance();
+
+		if (!voipModule.VarVoipEnabled->ValueInt == 0)
+		{
+			if (voipModule.voipConnected)
+			{
+				if (voipModule.VarPTTEnabled->ValueInt == 0)
+				{
+					if (voipModule.voiceDetected)
+						flags |= 0x400; //Bit10
+				}
+				else
+				{
+					if (Blam::Input::GetActionState(Blam::Input::eGameActionVoiceChat)->Ticks > 0)
+						flags |= 0x400; //Bit10
+				}
+			}
+		}
+
+		return flags;
 	}
 }

--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -57,7 +57,6 @@ namespace
 	void StateDataFlags5Hook();
 	void StateDataFlags21Hook();
 	void StateDataFlags31Hook();
-	void StateDataFlags33Hook();
 	int GetBrokenChudStateFlags2Values();
 	int GetBrokenChudStateFlags3Values();
 	int GetBrokenChudStateFlags5Values();
@@ -199,7 +198,6 @@ namespace Patches::Ui
 		Hook(0x687094, StateDataFlags5Hook).Apply();
 		Hook(0x687BF0, StateDataFlags21Hook).Apply();
 		Hook(0x685A5A, StateDataFlags31Hook).Apply();
-		Hook(0x685815, StateDataFlags33Hook).Apply();
 	}
 
 	const auto UI_Alloc = reinterpret_cast<void *(__cdecl *)(int32_t)>(0xAB4ED0);
@@ -1230,6 +1228,12 @@ namespace
 		{
 			call GetBrokenChudStateFlags2Values
 			or word ptr[edi + 57Ah], ax
+
+			//Since biped flags are regularly updated,
+			//Fix flags additions to flags33 here too, to also be regularly updated.
+			call GetBrokenChudStateFlags33Values
+			or [edi + 5B0h], eax
+
 			mov eax, 0xA86FC8
 			jmp eax
 		}
@@ -1277,18 +1281,6 @@ namespace
 			call GetBrokenChudStateFlags31Values
 			or [edi + 5ACh], eax
 			mov eax, 0xA85A71
-			jmp eax
-		}
-	}
-
-	__declspec(naked) void StateDataFlags33Hook()
-	{
-		__asm
-		{
-			call GetBrokenChudStateFlags33Values
-			or [edi + 5B0h], eax
-			and dword ptr[edi + 5B0h], 0xFFFFFC1F //perform original instruction
-			mov eax, 0xA8581F
 			jmp eax
 		}
 	}

--- a/ElDorito/Source/Patches/Ui.hpp
+++ b/ElDorito/Source/Patches/Ui.hpp
@@ -41,6 +41,6 @@ namespace Patches::Ui
 	void ToggleSpeakingPlayerName(std::string name, bool speaking);
 	void UpdateSpeakingPlayerWidget(bool mapLoaded);
 
-	void UpdateHUDDistortion(bool mapLoaded);
+	void UpdateHUDDistortion();
 	void ToggleHUDDistortion(bool enabled);
 }

--- a/ElDorito/Source/Patches/Ui.hpp
+++ b/ElDorito/Source/Patches/Ui.hpp
@@ -34,15 +34,12 @@ namespace Patches::Ui
 	void FindUiTagData();
 	void FindUiTagIndices();
 	void FindVoiceChatSpeakingPlayerTagData();
-	void FindVoiceChatIconsTagData();
 	void FindHUDDistortionTagData();
 	void FindHUDResolutionTagData();
 
 	void TogglePTTSound(bool enabled);
 	void ToggleSpeakingPlayerName(std::string name, bool speaking);
 	void UpdateSpeakingPlayerWidget(bool mapLoaded);
-
-	void UpdateVoiceChatHUD(bool mapLoaded);
 
 	void UpdateHUDDistortion(bool mapLoaded);
 	void ToggleHUDDistortion(bool enabled);

--- a/ElDorito/Source/Web/Bridge/Client/ClientFunctions.cpp
+++ b/ElDorito/Source/Web/Bridge/Client/ClientFunctions.cpp
@@ -546,7 +546,6 @@ namespace Anvil::Client::Rendering::Bridge::ClientFunctions
 		}
 
 		Modules::ModuleVoIP::Instance().voiceDetected = value->value.GetBool();
-		Patches::Ui::UpdateVoiceChatHUD(false);
 
 		if (Modules::ModuleVoIP::Instance().VarSpeakingPlayerOnHUD->ValueInt == 1)
 		{
@@ -566,8 +565,6 @@ namespace Anvil::Client::Rendering::Bridge::ClientFunctions
 		}
 
 		Modules::ModuleVoIP::Instance().voipConnected = value->value.GetBool();
-
-		Patches::Ui::UpdateVoiceChatHUD(false);
 
 		return QueryError_Ok;
 	}


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Fixed an issue where HUD biped state was fixed to spartan, affecting the elite and monitor HUD.

2. Refactored voice chat icons, now instead of editing tags to show or hide the icons, the state flags left in from halo 3 are used.

3. Fixed a couple of small issues with equipment icons. Swapping equipment now causes the equipment pickup animation to occur on the HUD. After initial spawn there is no longer a delay before icons appear.

4. Fixed a small issue with HUD distortion.

5. Restored Halo3's Flags1 Bit2 and Bit3. Now located at Flags33 Bit12 and Bit13.

### Why should this pull request be merged?
Fixes bugs.
### Have you tested this on your own and/or in a game with other people?
Tested alone.
### Notes
Tag changes are recommended. HUD fix-up update will be shared shortly.

