### PR TITLE
Move Direct x EndScene hook and hopefully fix screenshot folder creation.

### DIFF
--- a/ElDorito/Source/Modules/ModuleGame.cpp
+++ b/ElDorito/Source/Modules/ModuleGame.cpp
@@ -922,10 +922,8 @@ namespace
 	bool CommandGameTakeScreenshot(const std::vector<std::string>& Arguments, std::string& returnInfo)
 	{
 		wchar_t *path = Blam::Graphics::TakeScreenshot();
-		wchar_t full_path[400];
-		_wfullpath(full_path, path, 400);
 		std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_to_string;
-		std::string screenshot_path = wstring_to_string.to_bytes(full_path);
+		std::string screenshot_path = wstring_to_string.to_bytes(path);
 
 		rapidjson::StringBuffer jsonBuffer;
 		rapidjson::Writer<rapidjson::StringBuffer> jsonWriter(jsonBuffer);


### PR DESCRIPTION
### Proposed changes in this pull request:
EndScene Hook

This moves the CEF EndScene hook to run just before the games screenshot saving code. This also fixes the CEF overlay being displayed on top of the steam overlay since the game no long hooks EndScene directly.

Screenshot Folder Creation

Had a bunch of issues with this but it should hopefully be fully fixed now unless someone finds new edge cases.

### Why should this pull request be merged?
It fixes the folder creation bug, #278 and #276 (if I understand that one correctly).
### Have you tested this on your own and/or in a game with other people?
yes