### PR TITLE
Forge UI - Correcting Armor Ability names

### DIFF
--- a/dist/mods/ui/web/screens/forge/object_creation/items.xml
+++ b/dist/mods/ui/web/screens/forge/object_creation/items.xml
@@ -229,8 +229,8 @@
         <item name="Invincibility" tagindex="0x1a6c" />
         <item name="Vehicle Camo" tagindex="0x1563" />
         <item name="Lightning Strike" tagindex="0x1573" />
-        <item name="Mag Pulse" tagindex="0x156d" />
-        <item name="Reactive Armor" tagindex="0x156f" />
+        <item name="Shockwave" tagindex="0x156d" />
+        <item name="Reflective Shield" tagindex="0x156f" />
         <item name="Roadblock" tagindex="0x1571" />
         <item name="Vision" tagindex="0x1577" />
       </category>


### PR DESCRIPTION
Renamed "Reactive Armor" to "Reflective Shield" and renamed "mag pulse" to "Shock Wave"

### Why should this pull request be merged?
To make sure the ui matches the strings in the hud
### Have you tested this on your own and/or in a game with other people?
yes