### PR TITLE
Implement a LAN server detection backend and frontend.

### DIFF
--- a/ElDorito/ElDorito.vcxproj
+++ b/ElDorito/ElDorito.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="Source\CommandMap.cpp" />
     <ClCompile Include="Source\Console.cpp" />
     <ClCompile Include="Source\Forge\KillVolumes.cpp" />
+    <ClCompile Include="Source\Modules\ModuleLanDiscoveryListener.cpp" />
     <ClCompile Include="Source\Patches\BottomlessClip.cpp" />
     <ClCompile Include="Source\Patches\DirectXHook.cpp" />
     <ClCompile Include="Source\ElDorito.cpp" />
@@ -113,6 +114,7 @@
     <ClCompile Include="Source\Pointer.cpp" />
     <ClCompile Include="Source\Server\BanList.cpp" />
     <ClCompile Include="Source\Server\DedicatedServer.cpp" />
+    <ClCompile Include="Source\Server\LanBroadcast.cpp" />
     <ClCompile Include="Source\Server\Stats.cpp" />
     <ClCompile Include="Source\Server\Rcon.cpp" />
     <ClCompile Include="Source\Server\ServerChat.cpp" />
@@ -234,6 +236,7 @@
     <ClInclude Include="Source\CommandMap.hpp" />
     <ClInclude Include="Source\Console.hpp" />
     <ClInclude Include="Source\Forge\KillVolumes.hpp" />
+    <ClInclude Include="Source\Modules\ModuleLanDiscoveryListener.hpp" />
     <ClInclude Include="Source\Patches\BottomlessClip.hpp" />
     <ClInclude Include="Source\Patches\DirectXHook.hpp" />
     <ClInclude Include="Source\ElDorito.hpp" />
@@ -296,6 +299,7 @@
     <ClInclude Include="Source\resource.h" />
     <ClInclude Include="Source\Server\BanList.hpp" />
     <ClInclude Include="Source\Server\DedicatedServer.hpp" />
+    <ClInclude Include="Source\Server\LanBroadcast.hpp" />
     <ClInclude Include="Source\Server\Stats.hpp" />
     <ClInclude Include="Source\Server\Rcon.hpp" />
     <ClInclude Include="Source\Server\ServerChat.hpp" />
@@ -433,7 +437,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;_ENABLE_ATOMIC_ALIGNMENT_FIX;_DEBUG;NOMINMAX;PSAPI_VERSION=1;MINIUPNP_STATICLIB;ElDorito_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_ENABLE_ATOMIC_ALIGNMENT_FIX;_DEBUG;NOMINMAX;PSAPI_VERSION=1;MINIUPNP_STATICLIB;ElDorito_EXPORTS;RAPIDJSON_HAS_STDSTRING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -478,7 +482,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;_ENABLE_ATOMIC_ALIGNMENT_FIX;NDEBUG;NOMINMAX;PSAPI_VERSION=1;MINIUPNP_STATICLIB;ElDorito_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_ENABLE_ATOMIC_ALIGNMENT_FIX;NDEBUG;NOMINMAX;PSAPI_VERSION=1;MINIUPNP_STATICLIB;ElDorito_EXPORTS;RAPIDJSON_HAS_STDSTRING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <DebugInformationFormat>
       </DebugInformationFormat>

--- a/ElDorito/ElDorito.vcxproj.filters
+++ b/ElDorito/ElDorito.vcxproj.filters
@@ -1115,17 +1115,14 @@
     </ClInclude>
     <ClInclude Include="Source\Server\DedicatedServer.hpp" />
     <ClInclude Include="Source\Patches\Medals.hpp" />
-<<<<<<< 15b9fa9dd810071f396a6c21da39d3179992a3be
     <ClInclude Include="Source\Patches\Simulation.hpp" />
     <ClInclude Include="Source\Forge\KillVolumes.hpp" />
-=======
     <ClInclude Include="Source\Server\LanBroadcast.hpp">
       <Filter>Server</Filter>
     </ClInclude>
     <ClInclude Include="Source\Modules\ModuleLanDiscoveryListener.hpp">
       <Filter>Modules</Filter>
     </ClInclude>
->>>>>>> e1bf1f49656b5e992083b4b437d0da8a4b40388a
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Source\ElDorito.rc" />

--- a/ElDorito/ElDorito.vcxproj.filters
+++ b/ElDorito/ElDorito.vcxproj.filters
@@ -474,6 +474,12 @@
     <ClCompile Include="Source\Patches\Medals.cpp" />
     <ClCompile Include="Source\Patches\Simulation.cpp" />
     <ClCompile Include="Source\Forge\KillVolumes.cpp" />
+    <ClCompile Include="Source\Server\LanBroadcast.cpp">
+      <Filter>Server</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Modules\ModuleLanDiscoveryListener.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Blam\BitStream.hpp">
@@ -1109,8 +1115,17 @@
     </ClInclude>
     <ClInclude Include="Source\Server\DedicatedServer.hpp" />
     <ClInclude Include="Source\Patches\Medals.hpp" />
+<<<<<<< 15b9fa9dd810071f396a6c21da39d3179992a3be
     <ClInclude Include="Source\Patches\Simulation.hpp" />
     <ClInclude Include="Source\Forge\KillVolumes.hpp" />
+=======
+    <ClInclude Include="Source\Server\LanBroadcast.hpp">
+      <Filter>Server</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Modules\ModuleLanDiscoveryListener.hpp">
+      <Filter>Modules</Filter>
+    </ClInclude>
+>>>>>>> e1bf1f49656b5e992083b4b437d0da8a4b40388a
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Source\ElDorito.rc" />

--- a/ElDorito/Source/ElModules.cpp
+++ b/ElDorito/Source/ElModules.cpp
@@ -17,6 +17,7 @@
 #include "Modules/ModuleForge.hpp"
 #include "Modules/ModuleVoIP.hpp"
 #include "Modules/ModuleTweaks.hpp"
+#include "Modules/ModuleLanDiscoveryListener.hpp"
 
 namespace
 {
@@ -119,6 +120,7 @@ namespace Modules
 		ModuleForge::Instance();
 		ModuleVoIP::Instance();
 		ModuleTweaks::Instance();
+		ModuleLanDiscoveryListener::Instance();
 
 		AddCommand("Help", "help", "Displays this help text", eCommandFlagsNone, CommandHelp);
 		AddCommand("Execute", "exec", "Executes a list of commands", eCommandFlagsNone, CommandExecute, { "filename(string) The list of commands to execute" });

--- a/ElDorito/Source/Modules/ModuleGame.cpp
+++ b/ElDorito/Source/Modules/ModuleGame.cpp
@@ -1,4 +1,5 @@
 #include "ModuleGame.hpp"
+#include "ModuleLanDiscoveryListener.hpp"
 #include <sstream>
 #include <fstream>
 #include <type_traits>
@@ -26,6 +27,7 @@
 #include <unordered_map>
 #include <codecvt>
 #include "../Blam/Tags/Camera/AreaScreenEffect.hpp"
+#include "../Console.hpp"
 
 namespace
 {

--- a/ElDorito/Source/Modules/ModuleGame.hpp
+++ b/ElDorito/Source/Modules/ModuleGame.hpp
@@ -23,6 +23,7 @@ namespace Modules
 		Command* VarScreenshotsFolder;
 		Command* VarCefMedals;
 		Command* VarFpsLimiter;
+		Command* VarRunListener;
 
 		int DebugFlags;
 

--- a/ElDorito/Source/Modules/ModuleLanDiscoveryListener.cpp
+++ b/ElDorito/Source/Modules/ModuleLanDiscoveryListener.cpp
@@ -1,0 +1,107 @@
+#include "ModuleLanDiscoveryListener.hpp"
+#include "ModuleServer.hpp"
+#include <sstream>
+#include "../ElDorito.hpp"
+#include "../Server/LanBroadcast.hpp"
+#include "../Web/Ui/ScreenLayer.hpp"
+#include "../ThirdParty/rapidjson/writer.h"
+#include "../ThirdParty/rapidjson/document.h"
+#include "../ThirdParty/rapidjson/stringbuffer.h"
+#include "../Utils/Logger.hpp"
+
+namespace
+{
+	std::string process_raw_packet(char *packet)
+	{
+		char header[HEADER_SIZE];
+		char content[packet_size];
+		char data[MAX_DATA_SIZE + sizeof(char)];
+		strncpy(content, &packet[HEADER_SIZE - 1], packet_size);
+		strncpy_s(header, HEADER_SIZE, packet, HEADER_SIZE - 1);
+		if (strcmp(header, HEADER) != 0)
+			return "";
+		int data_size = content[0];
+		strncpy_s(data, sizeof(data), &content[1], data_size);
+		return std::string(data);
+	}
+
+	bool is_listening = false;
+	DWORD WINAPI LanListenerThread(LPVOID)
+	{
+		is_listening = true;
+		SOCKET listener_socket = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+		if (listener_socket == -1)
+		{
+			is_listening = false;
+			return 0;
+		}
+
+		char broadcast_value = 1;
+		setsockopt(listener_socket, SOL_SOCKET, SO_REUSEADDR, &broadcast_value, sizeof(char));
+		SOCKADDR_IN ListnerAddr;
+		memset(&ListnerAddr, 0, sizeof(ListnerAddr));
+		ListnerAddr.sin_family = AF_INET;
+		int port = Modules::ModuleServer::Instance().VarServerBroadcastPort->ValueInt;
+		ListnerAddr.sin_port = htons(port);
+		ListnerAddr.sin_addr.s_addr = INADDR_ANY;
+
+		if (bind(listener_socket, (SOCKADDR *)&ListnerAddr, sizeof(SOCKADDR_IN)) < 0)
+		{
+			is_listening = false;
+			return 0;
+		}
+		while (is_listening)
+		{
+			char rbuf[packet_size];
+			SOCKADDR_IN broadcaster_addr;
+			int len = sizeof(broadcaster_addr);
+			if (recvfrom(listener_socket, rbuf, sizeof(rbuf), 0, (sockaddr*)&broadcaster_addr, &len) > 0)
+			{
+				std::string data = process_raw_packet(rbuf);
+				std::string ip_addr = inet_ntoa(broadcaster_addr.sin_addr);
+				rapidjson::Document parsed_data;
+				parsed_data.Parse(data.c_str());
+				if (parsed_data.HasParseError()) {
+					Utils::Logger::Instance().Log(Utils::LogTypes::Network, Utils::LogLevel::Error, "LanDiscovery: Error Processing string:'" + data + "' sent by " + ip_addr);
+					continue;
+				}
+
+				auto& allocator = parsed_data.GetAllocator();
+				rapidjson::Value key("server_address", allocator);
+				rapidjson::Value value(ip_addr, allocator);
+				parsed_data.AddMember(key, value, allocator);
+
+				rapidjson::StringBuffer buffer;
+				rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+				parsed_data.Accept(writer);
+
+				Web::Ui::ScreenLayer::Notify("received_broadcast", buffer.GetString(), true);
+			}
+		}
+		return 0;
+	}
+
+	bool CommandStart(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		if (!is_listening)
+			CreateThread(nullptr, 0, LanListenerThread, nullptr, 0, nullptr);
+		returnInfo = "Started Lan Listener";
+		return true;
+	}
+
+	bool CommandStop(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		is_listening = false;
+		returnInfo = "Stopped Lan Listener";
+		return true;
+	}
+}
+
+namespace Modules
+{
+	ModuleLanDiscoveryListener::ModuleLanDiscoveryListener() : ModuleBase("LanDiscoveryListener")
+	{
+		AddCommand("Start", "lan_listener_start", "Starts the lan listener", eCommandFlagsNone, CommandStart);
+		AddCommand("Stop", "lan_listener_stop", "Stops the lan listener", eCommandFlagsNone, CommandStop);
+	}
+}

--- a/ElDorito/Source/Modules/ModuleLanDiscoveryListener.hpp
+++ b/ElDorito/Source/Modules/ModuleLanDiscoveryListener.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "ModuleBase.hpp"
+
+namespace Modules
+{
+	class ModuleLanDiscoveryListener : public Utils::Singleton<ModuleLanDiscoveryListener>, public ModuleBase
+	{
+	public:
+		ModuleLanDiscoveryListener();
+	};
+}

--- a/ElDorito/Source/Modules/ModuleServer.cpp
+++ b/ElDorito/Source/Modules/ModuleServer.cpp
@@ -1274,6 +1274,10 @@ namespace Modules
 		VarServerGamePort->ValueIntMin = 1;
 		VarServerGamePort->ValueIntMax = 0xFFFF;
 
+		VarServerBroadcastPort = AddVariableInt("LanBroadcastPort", "server_broadcast_port", "Used by lan auto discovery, don't change this unless you know what you are doing", eCommandFlagsHidden, 11773);
+		VarServerGamePort->ValueIntMin = 1;
+		VarServerGamePort->ValueIntMax = 0xFFFF;
+
 		VarServerShouldAnnounce = AddVariableInt("ShouldAnnounce", "should_announce", "Controls whether the server will be announced to the master servers", eCommandFlagsArchived, 1, VariableServerShouldAnnounceUpdate);
 		VarServerShouldAnnounce->ValueIntMin = 0;
 		VarServerShouldAnnounce->ValueIntMax = 1;

--- a/ElDorito/Source/Modules/ModuleServer.hpp
+++ b/ElDorito/Source/Modules/ModuleServer.hpp
@@ -18,6 +18,7 @@ namespace Modules
 		Command* VarServerMaxPlayers;
 		Command* VarServerPort;
 		Command* VarServerGamePort;
+		Command* VarServerBroadcastPort;
 		Command* VarServerShouldAnnounce;
 		Command* VarServerSprintEnabled;
 		Command* VarServerSprintEnabledClient;

--- a/ElDorito/Source/Patches/Network.cpp
+++ b/ElDorito/Source/Patches/Network.cpp
@@ -24,6 +24,7 @@
 #include "../Utils/Logger.hpp"
 #include "../Web/Ui/ScreenLayer.hpp"
 #include "../Server/Signaling.hpp"
+#include "../Server/LanBroadcast.hpp"
 
 namespace
 {
@@ -575,11 +576,13 @@ namespace
 		{
 			Patches::Network::StartInfoServer();
 			Server::Signaling::StartServer();
+			Server::LanBroadcast::StartServer();
 		}
 		else
 		{
 			Patches::Network::StopInfoServer();
 			Server::Signaling::StopServer();
+			Server::LanBroadcast::StopServer();
 		}
 
 		return retval;

--- a/ElDorito/Source/Patches/Ui.cpp
+++ b/ElDorito/Source/Patches/Ui.cpp
@@ -585,19 +585,7 @@ namespace Patches::Ui
 
 	void ShowLanBrowser()
 	{
-		typedef void*(__cdecl * UI_AllocPtr)(int size);
-		auto UI_Alloc = reinterpret_cast<UI_AllocPtr>(0xAB4ED0);
-		typedef void*(__fastcall* c_load_game_browser_screen_messagePtr)(void *thisPtr, int unused, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5);
-		auto c_load_game_browser_screen_message = reinterpret_cast<c_load_game_browser_screen_messagePtr>(0xADE0B0);
-		typedef void(*UI_Dialog_QueueLoadPtr)(void *dialog);
-		auto UI_Dialog_QueueLoad = reinterpret_cast<UI_Dialog_QueueLoadPtr>(0xA93450);
-
-		auto dialog = UI_Alloc(0x44);
-		if (!dialog)
-			return;
-		dialog = c_load_game_browser_screen_message(dialog, 0, 0x10355, 0, 4, 0x1000C, 0, 0);
-		if (dialog)
-			UI_Dialog_QueueLoad(dialog);
+		Web::Ui::ScreenLayer::Show("localbrowser", "{}");
 	}
 }
 

--- a/ElDorito/Source/Server/LanBroadcast.cpp
+++ b/ElDorito/Source/Server/LanBroadcast.cpp
@@ -1,0 +1,106 @@
+#include "LanBroadcast.hpp"
+
+#include <stdio.h>
+#include <tchar.h>
+#include <winsock2.h>
+#include <string>
+#include <iostream>
+#include <atlbase.h>
+
+#include "../Patches/CustomPackets.hpp"
+#include "../Patches/Network.hpp"
+#include "../ThirdParty/rapidjson/document.h"
+#include "../ThirdParty/rapidjson/stringbuffer.h"
+#include "../ThirdParty/rapidjson/writer.h"
+#include "../Blam/BlamEvents.hpp"
+#include "../Utils/Utils.hpp"
+#include "../Modules/ModuleServer.hpp"
+
+namespace
+{
+	DWORD WINAPI LanBroadcastThread(LPVOID);
+	bool is_broadcasting = false;
+}
+
+namespace Server::LanBroadcast
+{
+
+	void StartServer()
+	{
+		if (!is_broadcasting)
+			CreateThread(nullptr, 0, LanBroadcastThread, nullptr, 0, nullptr);
+	}
+
+	void StopServer()
+	{
+		is_broadcasting = false;
+	}
+}
+
+namespace
+{
+
+	std::string InfoServerPortJSON()
+	{
+		auto session = Blam::Network::GetActiveSession();
+		rapidjson::StringBuffer buffer;
+		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+		buffer.Clear();
+
+		writer.StartObject();
+		writer.Key("info_server_port");
+		std::string info_port = Modules::ModuleServer::Instance().VarServerPort->ValueString;
+		writer.String(info_port.c_str());
+
+		writer.EndObject();
+		return buffer.GetString();
+	}
+
+	void build_packet(char *packet, std::string data)
+	{
+		std::string packet_data = HEADER;
+		packet_data = packet_data + (char)data.size() + data;
+		memset(packet, 0x00, packet_size);
+		strncpy(packet, packet_data.c_str(), packet_data.size());
+	}
+
+	//websocket server
+	DWORD WINAPI LanBroadcastThread(LPVOID)
+	{
+		is_broadcasting = true;
+		char p[packet_size];
+
+		std::string data = InfoServerPortJSON();
+		if (data.size() > MAX_DATA_SIZE)
+			data = data.substr(0, MAX_DATA_SIZE);
+
+		build_packet(p, data);
+
+		WORD w = MAKEWORD(1, 1);
+		WSADATA wsadata;
+		::WSAStartup(w, &wsadata);
+
+
+		SOCKET broadcast_socket = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+		if (broadcast_socket == -1)
+		{
+			is_broadcasting = false;
+			return 0;
+		}
+		char broadcasting = true;
+		setsockopt(broadcast_socket, SOL_SOCKET, SO_BROADCAST, &broadcasting, sizeof(broadcasting));
+		SOCKADDR_IN brdcastaddr;
+		memset(&brdcastaddr, 0, sizeof(brdcastaddr));
+		brdcastaddr.sin_family = AF_INET;
+		int port = Modules::ModuleServer::Instance().VarServerBroadcastPort->ValueInt;
+		brdcastaddr.sin_port = htons(port);
+		brdcastaddr.sin_addr.s_addr = INADDR_BROADCAST;
+		while (is_broadcasting) {
+			sendto(broadcast_socket, p, strlen(p), 0, (sockaddr*)&brdcastaddr, sizeof(brdcastaddr));
+			Sleep(1500);
+		}
+		::closesocket(broadcast_socket);
+		return 0;
+	}
+
+}

--- a/ElDorito/Source/Server/LanBroadcast.hpp
+++ b/ElDorito/Source/Server/LanBroadcast.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#define HEADER "\x1B\x1B ED"
+#define HEADER_SIZE sizeof(HEADER)
+#define MAX_DATA_SIZE 255
+#define packet_size HEADER_SIZE + MAX_DATA_SIZE + sizeof(char)
+
+namespace Server::LanBroadcast
+{
+	void StartServer();
+	void StopServer();
+}
+

--- a/dist/mods/ui/web/screens/localbrowser/index.html
+++ b/dist/mods/ui/web/screens/localbrowser/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en-US">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
+        <title>Local Games Browser</title>
+        <link rel='stylesheet' href='localbrowser.css' type='text/css' media='all' />
+		<script type="text/javascript" src="dew://lib/dew.js"></script>
+		<script type="text/javascript" src="dew://lib/jquery-2.2.1.min.js"></script>
+        <script src='localbrowser.js'></script>
+    </head>
+    <body>
+        <div class="Container">
+            <div id="browser-title" class="center">LOCAL GAMES</div>
+			<button id="refresh">Refresh</button>
+            <table id="serverlist">
+                <thead>
+                    <tr>
+                        <th>Server</th>
+                        <th>Address</th>
+                        <th>Game Type</th>
+                        <th>Map</th>
+                        <th>Status</th>
+                        <th>Players</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </body>
+</html>

--- a/dist/mods/ui/web/screens/localbrowser/localbrowser.css
+++ b/dist/mods/ui/web/screens/localbrowser/localbrowser.css
@@ -1,0 +1,158 @@
+/*Reset
+-----------------------------*/
+
+*
+{
+	margin: 0;
+	padding: 0;
+}
+
+#container
+{
+	margin: 0 auto;
+	padding: 20px 0 0;
+	width: 960px;
+}
+
+
+iframe
+{
+	margin: 0 10px 20px;
+	width: 250px;
+}
+
+.photo
+{
+	width: 940px;
+}
+
+.column
+{
+	float: left;
+	width: 100%;
+}
+
+.clear
+{
+	clear: both;
+	overflow: hidden;
+	width: 0;
+	height: 0;
+}
+
+	
+
+/*Main
+-----------------------------*/
+
+body
+{
+	background-color: #05152f;
+}
+
+
+.Container
+{
+	margin: 40px 40px 40px 40px;
+	width: auto;
+	padding: 25px 20px 35px 20px;
+	height: auto;
+}
+
+
+
+#players-online {
+    font-size: 24px;
+    opacity: 0.8;
+    font-family:"Raleway", sans-serif;
+        background: -webkit-linear-gradient(#fff, #999);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: #fff;
+    margin-bottom:15px;
+}
+#browser-title {
+    font-weight: 700;
+    font-size: 50px;
+    padding-top:5px;
+    color: #fff;
+    font-family:"Raleway", sans-serif;
+	color:white;
+    background: -webkit-linear-gradient(#fff, #999);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+#refresh {
+	  width:100%;
+	  height:25px;
+	  margin-top: 15px;
+	  margin-bottom: 10px;
+}
+
+a
+{
+	color:White;
+	text-decoration:none;
+}
+
+a:hover 
+{
+	    color:white;
+}
+
+tr:hover 
+{
+	    background-color: rgba(255, 255, 255, 0.1);
+	    color: rgba(255,255,255,0.95);
+	 
+}
+
+#serverlist
+{
+	color:White;
+	margin-bottom:0px;
+	font-size:14px;
+	font-family:"Raleway", sans-serif;
+	background:rgba(255, 255, 255, 0.05);
+	width: 100%;
+}
+
+#serverlist > tbody > tr {
+	cursor: pointer;
+}
+
+#serverlist > thead > tr > th, #refresh {
+	background-color: rgba(255, 255, 255, 0.1);
+	color: rgba(255,255,255,0.95);
+}
+
+#refresh:hover {
+	background-color: rgba(255, 255, 255, 0.15);
+}
+
+.center {
+	text-align: center;
+}
+
+img.center {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+/*Tables	
+-----------------------------*/
+table {
+	margin-bottom:0px;
+	border-spacing:0px;
+}
+th {
+	font-weight:bold;
+	text-align: left;
+}
+
+td, th {
+	padding:15px 10px;
+	border-bottom:1px solid #555555;
+}

--- a/dist/mods/ui/web/screens/localbrowser/localbrowser.js
+++ b/dist/mods/ui/web/screens/localbrowser/localbrowser.js
@@ -1,0 +1,130 @@
+// UI and server info fetching code written by emoose
+var serverlist = new Map();
+
+function purge_old_servers(){
+	var update_need = false
+	for (var [server, last_broadcast] of serverlist) {
+		if ((Date.now() - last_broadcast) > 3500) {
+			serverlist.delete(server)
+			update_need = true
+		}
+	}
+	if (update_need)
+		updateServerList();
+}
+
+dew.on("received_broadcast", function(e){
+	var server_addr = e.data.server_address + ":" + e.data.info_server_port;
+	var existing = serverlist.has(server_addr)
+	serverlist.set(server_addr, Date.now())
+	if (!existing)
+		updateServerList();
+})
+
+dew.on("show", function(e){
+	dew.command("lan_listener_start");
+})
+
+dew.on("hide", function(){
+	dew.command("lan_listener_stop");
+})
+
+$("html").on("keydown", function(e) {
+    if (e.key == "Escape"){
+        dew.hide();
+    } 
+    if(e.keyCode == 192 || e.keyCode == 112 || e.keyCode == 223){
+        dew.show("console");
+    }
+});
+
+window.setInterval(purge_old_servers, 1000);
+window.setInterval(updateServerList, 10000); // refresh user data
+
+$("#refresh").click(function() {
+    updateServerList();
+});
+
+function connect_to_server(join_string)
+{
+	dew.command("connect " + join_string);
+	dew.hide();
+}
+
+function updateServerList() {
+    $("#serverlist > tbody").empty();
+
+	for (var [server, last_broadcast] of serverlist) {
+		queryServer(server);
+	}
+}
+    
+function queryServer(serverIP) {
+    var startTime = Date.now();
+    $.getJSON("http://" + serverIP, function(serverInfo) {
+        var timeTaken = Date.now() - startTime;
+        console.log(timeTaken);
+        if(serverInfo.name === undefined) return;
+        var isPassworded = serverInfo.passworded !== undefined;
+        //if no serverInfo.map, they jumped into an active game without unannouncing their server, causing a duplicate unjoinable game
+        if(!serverInfo.map) return;
+        
+	    //if any variables include js tags, skip them
+	    if(!invalidServer(serverInfo.name, serverInfo.variant, serverInfo.variantType, serverInfo.mapFile, serverInfo.maxPlayers, serverInfo.numPlayers, serverInfo.hostPlayer)) {
+            addServer(serverIP, isPassworded, serverInfo.name, serverInfo.hostPlayer, serverInfo.map, serverInfo.mapFile, serverInfo.variant, serverInfo.status, serverInfo.numPlayers, serverInfo.maxPlayers, serverInfo.eldewritoVersion, timeTaken);
+        }
+    });
+}
+
+function promptPassword(serverIP) {
+    var password = prompt("The server at " + serverIP + " is passworded, enter the password to join", "");
+    if(password != "")
+        connect_to_server(serverIP + ' ' + password);
+}
+
+function sanitizeString(str) {
+    return String(str).replace(/(<([^>]+)>)/ig,"") //shouldn't need to strip tags with the below replacements, but I'll keep it anyway
+                      .replace(/&/g, '&amp;')
+                      .replace(/</g, '&lt;')
+                      .replace(/>/g, '&gt;')
+                      .replace(/'/g, '&#39;')
+                      .replace(/"/g, '&quot;');
+}
+
+function invalidServer() {
+    if (/[<>]/.test(Array.prototype.slice.call(arguments).join(''))) {
+        console.log("Javascript potentially in one of the variables, skipping server");
+        return true;
+    } else {
+        return false;
+    }
+}
+
+function addServer(ip, isPassworded, name, host, map, mapfile, gamemode, status, numplayers, maxplayers, version, ping) {
+    //because people can't be trusted with html, filter it out
+    name = sanitizeString(name).substring(0,50);
+    host = sanitizeString(host).substring(0,50);
+    map = sanitizeString(map).substring(0,50);
+    mapfile = sanitizeString(mapfile).substring(0,50);
+    gamemode = sanitizeString(gamemode).substring(0,50);
+    status = sanitizeString(status).substring(0,50);
+    numplayers = parseInt(numplayers);
+    maxplayers = parseInt(maxplayers);
+    version = sanitizeString(version).substring(0, 10);
+
+    if (isPassworded) name = '[\uD83D\uDD12] ' + name;
+
+    if (version) name = '[' + version + '] ' + name;
+
+    var servName = "<td>" + name  + " <b>(" +  host + "</b>)" + "</td>";
+    var servMap = "<td>" + map + " (" + mapfile + ")" +  "</td>";
+    var servGameType = "<td>" + gamemode + "</br>" + "</td>";
+    var servIP = "<td>" + ip + "</td>";
+    var servStatus = "<td>" + status + "</td>";
+    var servPlayers = "<td>" + numplayers + "/" + maxplayers + "</td>";
+    
+	var onclick = (isPassworded ? 'promptPassword' : 'connect_to_server') + "('" + ip + "');";
+
+    //$('#serverlist tr:last').after
+    $('#serverlist > tbody').append("<tr onclick=\"" + onclick + "\">" + servName + servIP + servGameType + servMap +   servStatus + servPlayers + "</tr>");
+}

--- a/dist/mods/ui/web/screens/screens.json
+++ b/dist/mods/ui/web/screens/screens.json
@@ -120,6 +120,12 @@
 			"url": "dew://screens/screenshot_notice/",
 			"captureInput": false,
 			"zIndex": 90
+		},
+				{
+			"id": "localbrowser",
+			"url": "dew://screens/localbrowser/",
+			"captureInput": true,
+			"zIndex": 9
 		}
 	]
 }


### PR DESCRIPTION
This replaces the existing halo 3 LAN detection system with a new custom one using LAN broadcasting and CEF

### New system
Server broadcasts a JSON encoded message containing it's infoserver port to 11773 every 1.5 seconds

Client starts a listener on 11773 when the Lan browser UI is opened, and forwards the IP and info server port of broadcasting servers to the UI which can fetch server info from the infoserver.

### Old system

Client broadcasts a message to 11774 with a short header and some random data

Server responds with a broadcast to the port the client broadcasted from with server info like game mode, map, host, player count, etc, it also includes that random data that the client sent to it.

Client receives the broadcast, checks if the random data the server sent to it matches the one it send to it, if it does it parses the data and displays it to the user.

### Why should this pull request be merged?
It replaces the halo 3 LAN broadcasting system which has several issues such as not working correctly with multiple instances, #223 and not informing the user of a lot of the server metadata that normally available from the infoserver.
### Have you tested this on your own and/or in a game with other people?
Yes I tested it both with multiply instances on one system, dedicated servers and with different machines on the same LAN it would be useful to have people test it in more setups through, like over different VLAN system, etc.

Appveyor link if someone is able to test it but not build or unwilling to https://ci.appveyor.com/project/num0005/eldorito/build/0.6.0.3/artifacts .