### PR TITLE
[Rich Presence] Check if the lobby is online

### DIFF
--- a/ElDorito/Source/Discord/DiscordRPC.cpp
+++ b/ElDorito/Source/Discord/DiscordRPC.cpp
@@ -73,7 +73,10 @@ namespace
 			{
 				Discord::DiscordRPC::Instance().discordPresence.largeImageKey = "default";
 				Discord::DiscordRPC::Instance().discordPresence.largeImageText = "Mainmenu";
-				Discord::DiscordRPC::Instance().discordPresence.details = "In an Online Lobby";
+				if (Blam::Network::GetNetworkMode() == 3)
+					Discord::DiscordRPC::Instance().discordPresence.details = "In an Online Lobby";
+				else
+					Discord::DiscordRPC::Instance().discordPresence.details = "In an Offline Lobby";
 			}
 			else
 			{


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Shows if the lobby is online or offline

### Why should this pull request be merged?

It only currently shows online regardless of if the lobby is offline. No perf impact, only checking in lobby.

### Have you tested this on your own and/or in a game with other people?

Yes. Works.