### PR TITLE
Refactored HUD Distortion code.

### DIFF
--- a/ElDorito/Source/Modules/ModuleGraphics.cpp
+++ b/ElDorito/Source/Modules/ModuleGraphics.cpp
@@ -153,6 +153,12 @@ namespace
 		returnInfo = buffer.GetString();
 		return true;
 	}
+
+	bool VariableFlatHUDUpdated(const std::vector<std::string>& arguments, std::string& returnInfo)
+	{
+		Patches::Ui::UpdateHUDDistortion();
+		return true;
+	}
 }
 
 namespace Modules
@@ -192,6 +198,10 @@ namespace Modules
 		VarUIScaling = AddVariableInt("UIScaling", "uiscaling", "Enables proper UI scaling to match your monitor's resolution.", eCommandFlagsArchived, 1, VariableUIScalingUpdate);
 		VarUIScaling->ValueIntMin = 0;
 		VarUIScaling->ValueIntMax = 1;
+
+		VarFlatHUD = AddVariableInt("FlatHUD", "flathud", "Removes distortion from the HUD.", eCommandFlagsArchived, 0, VariableFlatHUDUpdated);
+		VarFlatHUD->ValueIntMin = 0;
+		VarFlatHUD->ValueIntMax = 1;
 
 		AddCommand("SupportedResolutions", "supported_resolutions", "List the supported screen resolutions", eCommandFlagsNone, CommandSupportedResolutions);
 	}

--- a/ElDorito/Source/Modules/ModuleGraphics.hpp
+++ b/ElDorito/Source/Modules/ModuleGraphics.hpp
@@ -18,6 +18,8 @@ namespace Modules
 		Command* VarDepthOfField;
 		Command* VarLetterbox;
 
+		Command* VarFlatHUD;
+
 		Command* VarUIScaling;
 
 		ModuleGraphics();

--- a/ElDorito/Source/Modules/ModuleTweaks.cpp
+++ b/ElDorito/Source/Modules/ModuleTweaks.cpp
@@ -1,15 +1,6 @@
 #include "ModuleTweaks.hpp"
 #include "../Patches/Ui.hpp"
 
-namespace
-{
-	bool VariableFlatHUDUpdated(const std::vector<std::string>& arguments, std::string& returnInfo)
-	{
-		Patches::Ui::UpdateHUDDistortion();
-		return true;
-	}
-}
-
 namespace Modules
 {
 	ModuleTweaks::ModuleTweaks() : ModuleBase("Tweaks")
@@ -45,9 +36,5 @@ namespace Modules
 		VarReachStyleFrags = AddVariableInt("ReachStyleFrags", "reachstylefrags", "Adds a Halo: Reach style trail effect to frag grenades.", eCommandFlagsArchived, 0);
 		VarReachStyleFrags->ValueIntMin = 0;
 		VarReachStyleFrags->ValueIntMax = 1;
-
-		VarFlatHUD = AddVariableInt("FlatHUD", "flathud", "Removes distortion from the HUD.", eCommandFlagsArchived, 0, VariableFlatHUDUpdated);
-		VarFlatHUD->ValueIntMin = 0;
-		VarFlatHUD->ValueIntMax = 1;
 	}
 }


### PR DESCRIPTION
Now a patch, not a tweak.

### Proposed changes in this pull request:

1. Removed HUD Distortion toggle tag changes. Replaced with a patch.

2. Moved flat HUD from tweaks to graphics.

3. Fixed an issue where the scripted camera would always disable HUD distortion.

### Why should this pull request be merged?
More efficient, more straightforward, less potential issues.

### Have you tested this on your own and/or in a game with other people?
Tested alone.