### PR TITLE
Custom HUD Colors and Fixed AllyBlue Player Markers.

### DIFF
--- a/ElDorito/Source/Modules/ModuleGraphics.cpp
+++ b/ElDorito/Source/Modules/ModuleGraphics.cpp
@@ -123,15 +123,9 @@ namespace
 	bool VariableCustomHUDColorsEnabledUpdate(const std::vector<std::string>& Arguments, std::string& returnInfo)
 	{
 		if (Modules::ModuleGraphics::Instance().VarCustomHUDColorsEnabled->ValueInt == 1)
-		{
-			Patches::Ui::customHUDColorsHook.Apply();
-			Patches::Ui::customWeaponOutlineColorHook.Apply();
-		}
+			Patches::Ui::enableCustomHUDColors = true;
 		else
-		{
-			Patches::Ui::customHUDColorsHook.Reset();
-			Patches::Ui::customWeaponOutlineColorHook.Reset();
-		}
+			Patches::Ui::enableCustomHUDColors = false;
 		return true;
 	}
 

--- a/ElDorito/Source/Modules/ModuleGraphics.cpp
+++ b/ElDorito/Source/Modules/ModuleGraphics.cpp
@@ -7,6 +7,7 @@
 #include "../Patches/Ui.hpp"
 #include "../ThirdParty/rapidjson/stringbuffer.h"
 #include "../ThirdParty/rapidjson/writer.h"
+#include <boost/regex.hpp>
 
 namespace
 {
@@ -119,6 +120,45 @@ namespace
 		return true;
 	}
 
+	bool VariableCustomHUDColorsEnabledUpdate(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		if (Modules::ModuleGraphics::Instance().VarCustomHUDColorsEnabled->ValueInt == 1)
+		{
+			Patches::Ui::customHUDColorsHook.Apply();
+			Patches::Ui::customWeaponOutlineColorHook.Apply();
+		}
+		else
+		{
+			Patches::Ui::customHUDColorsHook.Reset();
+			Patches::Ui::customWeaponOutlineColorHook.Reset();
+		}
+		return true;
+	}
+
+	bool VariableCustomHUDColorsUpdate(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		boost::cmatch what;
+		boost::regex expression("#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})");
+
+		if (boost::regex_match(Modules::ModuleGraphics::Instance().VarCustomHUDColorsPrimary->ValueString.c_str(), what, expression))
+			Patches::Ui::customPrimaryHUDColor = std::stoi(Modules::ModuleGraphics::Instance().VarCustomHUDColorsPrimary->ValueString.substr(1), 0, 16);
+		else
+		{
+			returnInfo = "Invalid Primary Color";
+			return false;
+		}
+
+		if (boost::regex_match(Modules::ModuleGraphics::Instance().VarCustomHUDColorsSecondary->ValueString.c_str(), what, expression))
+			Patches::Ui::customSecondaryHUDColor = std::stoi(Modules::ModuleGraphics::Instance().VarCustomHUDColorsSecondary->ValueString.substr(1), 0, 16);
+		else
+		{
+			returnInfo = "Invalid Secondary Color";
+			return false;
+		}
+
+		return true;
+	}
+
 	bool CommandSupportedResolutions(const std::vector<std::string>& Arguments, std::string& returnInfo)
 	{
 		DEVMODE devmode = { 0 };
@@ -192,6 +232,13 @@ namespace Modules
 		VarUIScaling = AddVariableInt("UIScaling", "uiscaling", "Enables proper UI scaling to match your monitor's resolution.", eCommandFlagsArchived, 1, VariableUIScalingUpdate);
 		VarUIScaling->ValueIntMin = 0;
 		VarUIScaling->ValueIntMax = 1;
+
+		VarCustomHUDColorsEnabled = AddVariableInt("CustomHUDColorsEnabled", "hud_colors", "Enables custom heads up display colors.", eCommandFlagsArchived, 0, VariableCustomHUDColorsEnabledUpdate);
+		VarCustomHUDColorsEnabled->ValueIntMin = 0;
+		VarCustomHUDColorsEnabled->ValueIntMax = 1;
+
+		VarCustomHUDColorsPrimary = AddVariableString("CustomHUDColorsPrimary", "hud_colors_1", "Change the primary custom HUD color.", eCommandFlagsArchived, "#0E6249", VariableCustomHUDColorsUpdate);
+		VarCustomHUDColorsSecondary = AddVariableString("CustomHUDColorsSecondary", "hud_colors_2", "Change the primary custom HUD color.", eCommandFlagsArchived, "#27CB9B", VariableCustomHUDColorsUpdate);
 
 		AddCommand("SupportedResolutions", "supported_resolutions", "List the supported screen resolutions", eCommandFlagsNone, CommandSupportedResolutions);
 	}

--- a/ElDorito/Source/Modules/ModuleGraphics.hpp
+++ b/ElDorito/Source/Modules/ModuleGraphics.hpp
@@ -18,6 +18,10 @@ namespace Modules
 		Command* VarDepthOfField;
 		Command* VarLetterbox;
 
+		Command* VarCustomHUDColorsEnabled;
+		Command* VarCustomHUDColorsPrimary;
+		Command* VarCustomHUDColorsSecondary;
+
 		Command* VarUIScaling;
 
 		ModuleGraphics();

--- a/ElDorito/Source/Modules/ModuleSettings.cpp
+++ b/ElDorito/Source/Modules/ModuleSettings.cpp
@@ -2,6 +2,7 @@
 #include "../Patches/Audio.hpp"
 #include "../ThirdParty/rapidjson/stringbuffer.h"
 #include "../ThirdParty/rapidjson/writer.h"
+#include "../Patches/Ui.hpp"
 
 namespace
 {
@@ -376,7 +377,16 @@ namespace
 
 		auto intValue = value == "default" ? 0 : value == "blue" ? 1 : 2;
 
-		SSL_SetTeamColor(intValue);
+		if (intValue == 1)
+		{
+			Patches::Ui::enableAllyBlueWaypointsFix = true;
+			SSL_SetTeamColor(0);
+		}
+		else
+		{ 
+			Patches::Ui::enableAllyBlueWaypointsFix = false;
+			SSL_SetTeamColor(intValue);
+		}
 
 		std::stringstream ss;
 		ss << "Player Marker Colors set to " << value << ".";

--- a/ElDorito/Source/Patches/Ui.hpp
+++ b/ElDorito/Source/Patches/Ui.hpp
@@ -7,6 +7,7 @@
 #include <Windows.h>
 
 #include "../Blam/Text/StringID.hpp"
+#include "../Patch.hpp"
 
 namespace Patches::Ui
 {
@@ -32,4 +33,9 @@ namespace Patches::Ui
 	void UpdateHUDDistortion();
 
 	void ShowLanBrowser();
+
+	extern Hook customHUDColorsHook;
+	extern Hook customWeaponOutlineColorHook;
+	extern int customPrimaryHUDColor;
+	extern int customSecondaryHUDColor;
 }

--- a/ElDorito/Source/Patches/Ui.hpp
+++ b/ElDorito/Source/Patches/Ui.hpp
@@ -34,8 +34,11 @@ namespace Patches::Ui
 
 	void ShowLanBrowser();
 
-	extern Hook customHUDColorsHook;
-	extern Hook customWeaponOutlineColorHook;
+	//These basically duplicate existing data from modules.
+	//However they make accessing in hooks a whole lot easier...
+	//Probably needs refactoring.
+	extern bool enableCustomHUDColors;
+	extern bool enableAllyBlueWaypointsFix;
 	extern int customPrimaryHUDColor;
 	extern int customSecondaryHUDColor;
 }


### PR DESCRIPTION
Defaults to off, with elite HUD colors saved.

### Proposed changes in this pull request:

1. Added commands to change and toggle custom HUD colors.
2. Fixed an issue where blue player markers caused icons (like the flag) to be black.

### Why should this pull request be merged?

Neat customization option.

### Have you tested this on your own and/or in a game with other people?

Tested alone.

### Images
Before player marker fix:
![Before](https://i.imgur.com/863MNsv.png)
After player marker fix:
![After](https://i.imgur.com/M9Eb4W8.png)

![Purple](https://i.imgur.com/vT4Zjn3.jpg)
![Pink](https://i.imgur.com/DYGcBrK.jpg)
![Green](https://i.imgur.com/AzJvGCQ.jpg)