### PR TITLE
Add offsets for missing Bomb, Oddball, and Flag

### DIFF
--- a/dist/mods/weapons/offsets/120FOV_Centered.json
+++ b/dist/mods/weapons/offsets/120FOV_Centered.json
@@ -1,6 +1,14 @@
 {
     "Weapons": [
         {
+            "Name": "assault_bomb",
+            "Offset": [
+                -0.08,
+                0.0,
+                -0.02
+            ]
+        },
+        {
             "Name": "assault_rifle",
             "Offset": [
                 -0.045,
@@ -241,6 +249,14 @@
             ]
         },
         {
+            "Name": "flag",
+            "Offset": [
+                -0.025,
+                0,
+                -0.03
+            ]
+        },
+        {
             "Name": "flak_cannon",
             "Offset": [
                 -0.035,
@@ -302,6 +318,14 @@
                 -0.07,
                 -0.004999,
                 -0.009999
+            ]
+        },
+        {
+            "Name": "oddball",
+            "Offset": [
+                -0.05,
+                0,
+                -0.04
             ]
         },
         {

--- a/dist/mods/weapons/offsets/CenteredCrosshair.json
+++ b/dist/mods/weapons/offsets/CenteredCrosshair.json
@@ -1,6 +1,14 @@
 {
     "Weapons": [
         {
+            "Name": "assault_bomb",
+            "Offset": [
+                -0.08,
+                0.0,
+                -0.02
+            ]
+        },
+        {
             "Name": "assault_rifle",
             "Offset": [
                 -0.037,
@@ -241,6 +249,14 @@
             ]
         },
         {
+            "Name": "flag",
+            "Offset": [
+                -0.01,
+                0,
+                -0.025
+            ]
+        },
+        {
             "Name": "flak_cannon",
             "Offset": [
                 -0.032,
@@ -302,6 +318,14 @@
                 -0.029999,
                 0.012,
                 -0.0015
+            ]
+        },
+        {
+            "Name": "oddball",
+            "Offset": [
+                -0.04,
+                0.0,
+                -0.03
             ]
         },
         {


### PR DESCRIPTION
Offsets the Assault Bomb, Oddball, and Flag weapons in
Centered/120FOV_Centered view models to be properly placed in player
hands.

### Proposed changes in this pull request:

1. Add Offsets for Assault Bomb, Oddball, and Flag weapons in Centered View Model. Works up to 110 FOV at least.

2. Add Offsets for Assault Bomb, Oddball, and Flag weapons in 120 FOV Centered View Model.

### Why should this pull request be merged?
Weapons should be properly placed in hands.
Screenshots of differences for 120 FOV Centered: https://imgur.com/a/lYUOn

### Have you tested this on your own and/or in a game with other people?
Yes.