### PR TITLE
Customization - add mouseOut event to emblem tiles

### DIFF
--- a/dist/mods/ui/web/screens/profile_settings/customization.css
+++ b/dist/mods/ui/web/screens/profile_settings/customization.css
@@ -63,3 +63,7 @@ form.emblemColorForm {
     box-sizing: border-box;
     display: block;
 }
+
+::-webkit-scrollbar {
+    width: 10px !important;
+}

--- a/dist/mods/ui/web/screens/profile_settings/customization.css
+++ b/dist/mods/ui/web/screens/profile_settings/customization.css
@@ -63,7 +63,3 @@ form.emblemColorForm {
     box-sizing: border-box;
     display: block;
 }
-
-::-webkit-scrollbar {
-    width: 10px !important;
-}

--- a/dist/mods/ui/web/screens/profile_settings/customization.js
+++ b/dist/mods/ui/web/screens/profile_settings/customization.js
@@ -936,6 +936,12 @@ function SetupEmblems(resetEmblemList, setRadiosLists, setEmblem, onFinish, runF
                         updateSelection(itemNumber, false, false);
                     });
 					
+					$('span').has('.setting').mouseout(function(){
+						if(!hasGP){
+							$(this).removeClass('selectedElement');
+						}
+					}); 
+					
 					if(setEmblem){
 						setItemValues('emblemIcon', embList.emblemList[getProperIndex(parseInt(getQueryVariable(data.emblem,'fi')),embList.emblemList)][1]);
 						setItemValues('emblemBackgroundImage', embList.backgroundEmblems[getProperIndex(parseInt(getQueryVariable(data.emblem,'bi')),embList.backgroundEmblems)][1]);


### PR DESCRIPTION
### Proposed changes in this pull request:

1.  bug is demonstrated in this video https://www.youtube.com/watch?v=tJvr3vfaz34

2. this code fixes it so the white selectedElement outline goes away when your mouse moves away from the tiles

### Why should this pull request be merged?
Fixes a bug
### Have you tested this on your own and/or in a game with other people?
Yes and it works as expected with the fix