### PR TITLE
Right Align the Host Crown on the Scoreboard

### DIFF
--- a/dist/mods/ui/web/screens/scoreboard/scoreboard.js
+++ b/dist/mods/ui/web/screens/scoreboard/scoreboard.js
@@ -549,7 +549,7 @@ function buildScoreboard(lobby, teamGame, scoreArray, gameType, playersInfo,expa
             } 
             $("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").prepend('<img class="emblem" src="'+emblemPath+'">');
 			if(lobby[i].isHost)
-			$("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="emblem" src="'+hostPath+'">');
+			$("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="emblem" style="float: right;" src="'+hostPath+'">');
             $("[data-playerIndex='" + lobby[i].playerIndex + "']").append($('<td class="serviceTag">').text(lobby[i].serviceTag))
             if(locked || (expandedScoreboard == 1)){
                 switch(gameType){


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Right Align the Host Crown on the Scoreboard so it looks nice.

### Why should this pull request be merged?

Makes it look like this:
![image](https://user-images.githubusercontent.com/6924950/37065176-cd8f7244-216d-11e8-83c6-532c95034ba7.png)

### Have you tested this on your own and/or in a game with other people?

Yes