### PR TITLE
Spectate UI - Align host crown to the right

### DIFF
--- a/dist/mods/ui/web/screens/spectate/spectate.js
+++ b/dist/mods/ui/web/screens/spectate/spectate.js
@@ -54,9 +54,9 @@ function showSpectateOverlay(i, lobby, teamGame, playersInfo){
 			emblemPath = 'dew://assets/emblems/generic.png'; 
 		}                
         $("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").prepend('<img class="emblem" src="'+emblemPath+'">');
+        $("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="arrows" src="sort_both.png">');
 		if(lobby[i].isHost)
 		$("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="emblem" src="'+hostPath+'" style="float: right;">');
-        $("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="arrows" src="sort_both.png">');
     }  
 }
 

--- a/dist/mods/ui/web/screens/spectate/spectate.js
+++ b/dist/mods/ui/web/screens/spectate/spectate.js
@@ -55,7 +55,7 @@ function showSpectateOverlay(i, lobby, teamGame, playersInfo){
 		}                
         $("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").prepend('<img class="emblem" src="'+emblemPath+'">');
 		if(lobby[i].isHost)
-		$("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="emblem" src="'+hostPath+'">');
+		$("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="emblem" src="'+hostPath+'" style="float: right;">');
         $("[data-playerIndex='" + lobby[i].playerIndex + "'] .name").append('<img class="arrows" src="sort_both.png">');
     }  
 }

--- a/dist/mods/ui/web/screens/voting/voting.css
+++ b/dist/mods/ui/web/screens/voting/voting.css
@@ -23,7 +23,7 @@ body{
     margin-top:10vh;
     color: #afbed5;
 	width: 20vw;
-	max-width: 384px;
+	max-width: 40vh;
 	border: 2px solid rgba(112, 128, 144, 0.7);
 	border-left: 0;
 	border-right:0;


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Changes the host crown to align to the right to match the scoreboard

2. Fixes the Voting UI scaling for 4k

### Why should this pull request be merged?
Looks cleaner and matches scoreboard and fixes a scaling issue
### Have you tested this on your own and/or in a game with other people?
Yes tested this in local game https://gyazo.com/fa3c7caa3adb9d38b1bd2b16a10e7d64

3840x2160
https://gyazo.com/20687bb6334b5d7b348af4a8ea69e787

1920x1080
https://gyazo.com/8f6fbc239dcec0e4879073f8f4435ec5

2560x1080
https://gyazo.com/216764991812fc26122695ddf86da519

1024x768
https://gyazo.com/c7166cb74513dc76349b46a3e9c2f46a