### PR TITLE
Add KOTH Hill Status Updates to Juggle Suppression

### DIFF
--- a/dist/mods/ui/web/screens/medals/medals.js
+++ b/dist/mods/ui/web/screens/medals/medals.js
@@ -47,13 +47,13 @@ dew.on("mpevent", function (event) {
                             var mstrVol = y/100;
                             playVol = sfxVol * mstrVol * 0.3;
                             var medal = event.data.name;
-                            if(suppressRepeat && ( medal.startsWith('ctf_event_flag_') || medal.startsWith('assault_event_bomb_') || medal.startsWith('oddball_event_ball'))){
+                            if(suppressRepeat && ( medal.startsWith('ctf_event_flag_') || medal.startsWith('assault_event_bomb_') || medal.startsWith('oddball_event_ball') || medal.startsWith('king_event_hill_c'))){
                                 juggleEvent++;
                                 setTimeout(function(){
                                     if(juggleEvent > 0){ juggleEvent--; }
                                 }, juggleDelay);
                             } 
-                            if(juggleEvent > 2 && ((medal.startsWith('oddball_event_ball') && (medal != 'oddball_event_ball_spawned' && medal != 'oddball_event_ball_reset')) || (medal.startsWith('ctf_event_flag_') && medal != 'ctf_event_flag_captured')||(medal.startsWith('assault_event_bomb_') && medal != 'assault_event_bomb_placed_on_enemy_post'))){
+                            if(juggleEvent > 2 && ((medal.startsWith('oddball_event_ball') && (medal != 'oddball_event_ball_spawned' && medal != 'oddball_event_ball_reset')) || (medal.startsWith('ctf_event_flag_') && medal != 'ctf_event_flag_captured')||(medal.startsWith('assault_event_bomb_') && medal != 'assault_event_bomb_placed_on_enemy_post') || medal.startsWith('king_event_hill_c'))){
                                 return
                             }
                             doMedal(event.data.name, event.data.audience);


### PR DESCRIPTION
This excludes the Hill Moved VO

### Proposed changes in this pull request:

1. All Hill Contested and Hill Controlled VOs are added to **Settings** > **Sound** > **Suppress Juggling Announcer Spam** filter

2. Hill Moved VO is excluded

### Why should this pull request be merged?

Like CTF, Assault, and Oddball, King of the Hill announcer VO can be spammed and this will stop it like the rest of the modes already supported by the setting.

### Have you tested this on your own and/or in a game with other people?

Yes