### PR TITLE
Network: update mod broadcast to use fmm.dat

### DIFF
--- a/ElDorito/Source/Patches/Network.cpp
+++ b/ElDorito/Source/Patches/Network.cpp
@@ -224,7 +224,7 @@ namespace Patches::Network
 					writer.Key("numPlayers");
 					writer.Int(GetNumPlayers());
 
-					std::ifstream file("fmmRequired.dat");
+					std::ifstream file("fmm.dat");
 					std::string temp;
 
 					writer.Key("mods");


### PR DESCRIPTION
Instead of fmmRequired.dat which was never used in a released FMM version (originally added to ED to facilitate FMM mod syncing). This would instead give server browsers the potential to show which mods a server is running.