### PR TITLE
Chat UI - Fix first messages shown being green

### DIFF
--- a/dist/mods/ui/web/screens/chat/chat.js
+++ b/dist/mods/ui/web/screens/chat/chat.js
@@ -204,7 +204,7 @@ dew.on("chat", function(e){
     }
     var messageClass = 'nameCard';
     var chatClass = e.data.chatType;
-    if((e.data.message).match(playerName)){
+    if((e.data.message).match(playerName) && playerName != undefined){
         chatClass += ' mention';                
     }
     


### PR DESCRIPTION
### Proposed changes in this pull request:

1.  Fixes the first message appearing as a mention

### Why should this pull request be merged?
Fixes a bug
### Have you tested this on your own and/or in a game with other people?
Tested using 2 clients on Xennma's server using f6 to reset the html to replicate the first green message