### PR TITLE
New max controller port value

### DIFF
--- a/ElDorito/Source/Modules/ModuleInput.cpp
+++ b/ElDorito/Source/Modules/ModuleInput.cpp
@@ -673,7 +673,7 @@ namespace Modules
 
 		VarInputControllerPort = AddVariableInt("ControllerPort", "controllerport", "The port number of the player's controller.", eCommandFlagsArchived, 0);
 		VarInputControllerPort->ValueIntMin = 0;
-		VarInputControllerPort->ValueIntMax = 3;
+		VarInputControllerPort->ValueIntMax = 7;
 
 		AddCommand("Bind", "bind", "Binds a command to a key", eCommandFlagsArgsNoParse, CommandBind, { "key", "[+]command", "arguments" });
 		Patches::Input::RegisterDefaultInputHandler(KeyboardUpdated);


### PR DESCRIPTION
Eight instances of ElDewrito can be played simultaniously on one higher end PC using an Xbox One controller adapter(Actually nine including kb/m but eight is a nicer number). This will allow those who wish to run that many to do so.