### PR TITLE
Added more inappropriate service tags to the filter list.

### DIFF
--- a/ElDorito/Source/Modules/ModulePlayer.cpp
+++ b/ElDorito/Source/Modules/ModulePlayer.cpp
@@ -209,7 +209,7 @@ namespace Modules
 
 	bool ModulePlayer::ValidServiceTag(const std::string &tag)
 	{
-		static const std::unordered_set<std::string> filter = {"ANUS", "ARSE", "CLIT", "COCK", "COON", "CUNT", "DAGO", "DAMN","DICK", "DIKE", "DYKE", "FUCK", "GOOK", "HEEB", "HELL", "HOMO", "JIZZ", "KIKE", "KUNT", "KYKE", "MICK", "MUFF", "PAKI", "PISS", "POON", "PUTO", "SHIT", "SHIZ", "SLUT", "SMEG", "SPIC", "TARD", "TITS", "TWAT", "WANK", "NIGA"};
+		static const std::unordered_set<std::string> filter = {"ANUS", "ARSE", "CLIT", "COCK", "COON", "CUNT", "DAGO", "DAMN", "DICK", "DIKE", "DYKE", "FUCK", "GOOK", "HEEB", "HELL", "HOMO", "JIZZ", "KIKE", "KUNT", "KYKE", "MICK", "MUFF", "PAKI", "PISS", "POON", "PUTO", "SHIT", "SHIZ", "SLUT", "SMEG", "SPIC", "TARD", "TITS", "TWAT", "WANK", "NIGA", "FAG", "FAGG", "KYS"};
 
 		return tag.length() > 2 && tag.length() < 5
 			&& all_of(tag.begin(), tag.end(), [](auto c) { return c >= '0' && c <= 'Z'; })


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Added more service tags to the validation filter set.

### Why should this pull request be merged?
Tags like "KYS" are inappropriate and should not be tolerated.

### Have you tested this on your own and/or in a game with other people?
Tested alone.