### PR TITLE
Added a map load required notification to the Intel bloom fix.

### DIFF
--- a/dist/mods/ui/web/screens/settings/settings.js
+++ b/dist/mods/ui/web/screens/settings/settings.js
@@ -464,7 +464,7 @@ $(document).ready(function(){
         alertBox('This change requires a restart to take effect.', false);
     });
     $('#tIntelBloomPatch').on('change', function(){
-        alertBox('This change requires a restart to take effect.', false);
+        alertBox('This change takes effect next time you load a map.', false);
     });
     $('.cefMedals').on('change', function(){
         if(!$('#gCefMedals').is(":checked")){

--- a/dist/mods/ui/web/screens/settings/settings.js
+++ b/dist/mods/ui/web/screens/settings/settings.js
@@ -463,6 +463,9 @@ $(document).ready(function(){
     $('#sVsync').on('change', function(){
         alertBox('This change requires a restart to take effect.', false);
     });
+    $('#tIntelBloomPatch').on('change', function(){
+        alertBox('This change requires a restart to take effect.', false);
+    });
     $('.cefMedals').on('change', function(){
         if(!$('#gCefMedals').is(":checked")){
             alertBox('This setting only effects Custom medal packs. Turning them on now.', false);


### PR DESCRIPTION
### Proposed changes in this pull request:

1. Added a notification telling users that a restart is required to apply/reset the Intel bloom patch.

### Why should this pull request be merged?
Because some users forget to restart, and some users think they've made a mistake somewhere.

### Have you tested this on your own and/or in a game with other people?
Tested alone. 