### PR TITLE
Allows discord rich presence password string to be updated while serv…

### DIFF
--- a/ElDorito/Source/Modules/ModuleServer.cpp
+++ b/ElDorito/Source/Modules/ModuleServer.cpp
@@ -43,6 +43,14 @@ namespace
 		return true;
 	}
 
+	bool VariableServerPasswordUpdate(const std::vector<std::string>& Arguments, std::string& returnInfo)
+	{
+		//inform Discord our password was updated
+		Discord::DiscordRPC::Instance().UpdatePresence(Blam::Network::GetNetworkMode());
+
+		return true;
+	}
+
 	bool VariableServerCountdownUpdate(const std::vector<std::string>& Arguments, std::string& returnInfo)
 	{
 		unsigned long seconds = Modules::ModuleServer::Instance().VarServerCountdown->ValueInt;
@@ -1251,7 +1259,7 @@ namespace Modules
 		VarServerMessageClient = AddVariableString("MessageClient", "server_msg_client", "", eCommandFlagsInternal);
 		Server::VariableSynchronization::Synchronize(VarServerMessage, VarServerMessageClient);
 
-		VarServerPassword = AddVariableString("Password", "password", "The server password", eCommandFlagsArchived, "");
+		VarServerPassword = AddVariableString("Password", "password", "The server password", eCommandFlagsArchived, "", VariableServerPasswordUpdate);
 
 		VarServerCountdown = AddVariableInt("Countdown", "countdown", "The number of seconds to wait at the start of the game", eCommandFlagsArchived, 5, VariableServerCountdownUpdate);
 		VarServerCountdown->ValueIntMin = 0;


### PR DESCRIPTION
…er is online.

### Proposed changes in this pull request:

1. Allows a host to change the password while the server is online without breaking discord rich presence joins.

### Why should this pull request be merged?
Right now if you change the server password when already set to online, the Discord rich presence links are not updated with the new password.  This breaks joining through rich presence.

### Have you tested this on your own and/or in a game with other people?
Tested in game with 2 other folks.

Test steps
1. Set a password and then start server.
2. Have players join then leave through a discord invite.
3. Change password but keep server on.
4. Have them attempt to rejoin with same discord invite.
