### PR TITLE
Forge - Fix map modifier's gravity property being set incorrectly

### DIFF
--- a/ElDorito/Source/Web/Ui/WebForge.cpp
+++ b/ElDorito/Source/Web/Ui/WebForge.cpp
@@ -900,7 +900,7 @@ namespace
 		SerializeProperty(writer, "fx_tracing", screenFxProperties->Tracing / 255.0f);
 		SerializeProperty(writer, "map_disable_push_barrier", (int)((mapModifierProperties->Flags & Forge::ForgeMapModifierProperties::eMapModifierFlags_DisablePushBarrier) != 0));
 		SerializeProperty(writer, "map_disable_death_barrier", (int)((mapModifierProperties->Flags & Forge::ForgeMapModifierProperties::eMapModifierFlags_DisableDeathBarrier) != 0));
-		SerializeProperty(writer, "map_physics_gravity", mapModifierProperties->PhysicsGravity / 255.0f);
+		SerializeProperty(writer, "map_physics_gravity", 1.f - (mapModifierProperties->PhysicsGravity / 255.0f));
 
 		SerializeProperty(writer, "camera_fx_exposure", mapModifierProperties->CameraFxExposure / 255.0f);
 		SerializeProperty(writer, "camera_fx_bloom", mapModifierProperties->CameraFxBloom / 255.0f);

--- a/ElDorito/Source/Web/Ui/WebForge.cpp
+++ b/ElDorito/Source/Web/Ui/WebForge.cpp
@@ -900,7 +900,7 @@ namespace
 		SerializeProperty(writer, "fx_tracing", screenFxProperties->Tracing / 255.0f);
 		SerializeProperty(writer, "map_disable_push_barrier", (int)((mapModifierProperties->Flags & Forge::ForgeMapModifierProperties::eMapModifierFlags_DisablePushBarrier) != 0));
 		SerializeProperty(writer, "map_disable_death_barrier", (int)((mapModifierProperties->Flags & Forge::ForgeMapModifierProperties::eMapModifierFlags_DisableDeathBarrier) != 0));
-		SerializeProperty(writer, "map_physics_gravity", 1.f - (mapModifierProperties->PhysicsGravity / 255.0f));
+		SerializeProperty(writer, "map_physics_gravity", mapModifierProperties->PhysicsGravity / 255.0f);
 
 		SerializeProperty(writer, "camera_fx_exposure", mapModifierProperties->CameraFxExposure / 255.0f);
 		SerializeProperty(writer, "camera_fx_bloom", mapModifierProperties->CameraFxBloom / 255.0f);

--- a/dist/mods/ui/web/screens/forge/object_properties/object_properties.js
+++ b/dist/mods/ui/web/screens/forge/object_properties/object_properties.js
@@ -309,7 +309,7 @@
                         type: 'range',
                         label: 'Gravity',
                         meta: { min: 0, max: 1, step: 0.01 },
-                        getValue: () => properties.map_physics_gravity,
+                        getValue: () => 1.0-properties.map_physics_gravity,
                         setValue: (value) => onPropertyChange({ ['map_physics_gravity']: 1.0-value })
                     });
                 });


### PR DESCRIPTION
### Proposed changes in this pull request:
Fix map modifier's gravity property, which currently does not display correctly.

### Why should this pull request be merged?
It fixes a minor -albeit rather annoying- bug.

### Have you tested this on your own and/or in a game with other people?
Alone.