### PR TITLE
Forge - Fix kill volume and garbage volume reading the wrong properties

### DIFF
--- a/ElDorito/Source/Web/Ui/WebForge.cpp
+++ b/ElDorito/Source/Web/Ui/WebForge.cpp
@@ -810,8 +810,8 @@ namespace
 		auto screenFxProperties = reinterpret_cast<const Forge::ForgeScreenFxProperties*>(&properties.RadiusWidth);
 		auto reforgeProperties = reinterpret_cast<const Forge::ReforgeObjectProperties*>(&properties.RadiusWidth);
 		auto mapModifierProperties = reinterpret_cast<const Forge::ForgeMapModifierProperties*>(&properties.RadiusWidth);
-		auto garbageVolumeProperties = reinterpret_cast<const Forge::ForgeGarbageVolumeProperties*>(&properties.RadiusWidth);
-		auto killVolumeProperties = reinterpret_cast<const Forge::ForgeKillVolumeProperties*>(&properties.RadiusWidth);
+		auto garbageVolumeProperties = reinterpret_cast<const Forge::ForgeGarbageVolumeProperties*>(&properties.TeleporterChannel);
+		auto killVolumeProperties = reinterpret_cast<const Forge::ForgeKillVolumeProperties*>(&properties.TeleporterChannel);
 
 		writer.StartObject();
 		SerializeProperty(writer, "tag_index", int(budget.TagIndex));


### PR DESCRIPTION
### Proposed changes in this pull request:
Make garbageVolumeProperties and killVolumeProperties read the correct address in SerializeObjectProperties!

### Why should this pull request be merged?
Fixes a bug..

### Have you tested this on your own and/or in a game with other people?
Alone.