### PR TITLE
Fix Tumblr HTTPS mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**ElDewrito development is on hold right now. We are not accepting issue reports or pull requests. For more information, please see our [blog](https://blog.eldewrito.com/).**
+**ElDewrito development is on hold right now. We are not accepting issue reports or pull requests. For more information, please see our [blog](http://blog.eldewrito.com/).**
 
 <img src="http://i.imgur.com/IkTrjna.png" width="190" height="164" align="right"/>
 


### PR DESCRIPTION
As the blog is being served by Tumblr, when you visit the blog subdomain using https, the certificate is mismatched (wrong domain). So anyone clicking on this link will get redirected to an error page. Easy fix, just direct people to the insecure page, as that's what's happening after the HTTPS connection anyway.

### Proposed changes in this pull request:

1. Change blog link to non-SSL!