### PR TITLE
Correct discord links(2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ElDewrito is a fan mod for Halo Online that enables LAN-based online multiplayer
 
 Note that this is the source code repo for it, not the mod itself. You'll need a copy of Halo Online and the ElDewrito Launcher to install ED.
 
-Pull requests are welcomed from anyone who wants to contribute to us. We recommend that you come talk to us on [Discord](https://discord.gg/halo) first before starting work on anything major, so that we can discuss it and come up with the best way to help you implement it. Also, please use Visual Studio to edit and test your code. Pull requests which were clearly made with GitHub's online editor will be rejected. Your commits should be meaningful and represent logical increments in functionality.
+Pull requests are welcomed from anyone who wants to contribute to us. We recommend that you come talk to us on [Discord](https://discord.gg/0TKY0SDEUHAWL4sG) first before starting work on anything major, so that we can discuss it and come up with the best way to help you implement it. Also, please use Visual Studio to edit and test your code. Pull requests which were clearly made with GitHub's online editor will be rejected. Your commits should be meaningful and represent logical increments in functionality.
 
 ## Download
 You should always check for the latest builds of ElDewrito on [AppVeyor](https://ci.appveyor.com/project/medsouz/eldorito/branch/master/artifacts) or our [subreddit](https://www.reddit.com/r/HaloOnline/).
@@ -25,7 +25,7 @@ We don't accept donations, donate money to your favorite charity instead.
 Although if you have a spare server running [ElDewrito-MasterServer](https://github.com/ElDewrito/ElDewrito-MasterServer) on it would be welcomed, get in touch with us on IRC and we can help you set this up.
 
 ## Help/Support/Contact
-We have a [Discord server](https://discord.gg/halo) that stays pretty active with helpful users.
+We have a [Discord server](https://discord.gg/0TKY0SDEUHAWL4sG) that stays pretty active with helpful users.
 
 You can also try checking the support question on the [subreddit](https://www.reddit.com/r/HaloOnline/).
 


### PR DESCRIPTION
not sure if that was intentional but "discord.gg/halo" go's to the /r/halo SubReddit's Discord now.

i know it says "We are not accepting issue reports or pull requests." but i though this would be an exception. 
### Proposed changes in this pull request:

1. Discord invite links

### Why should this pull request be merged?
this just makes sense...

### Have you tested this on your own and/or in a game with other people?
no. but does not apply.
